### PR TITLE
Add numeric state_ids to sensor readings

### DIFF
--- a/confluent_server/confluent/messages.py
+++ b/confluent_server/confluent/messages.py
@@ -746,6 +746,8 @@ class SensorReadings(ConfluentMessage):
                 sensordict['units'] = sensor['units']
             if 'states' in sensor:
                 sensordict['states'] = sensor['states']
+            if 'state_ids' in sensor:
+                sensordict['state_ids'] = sensor['state_ids']
             if 'health' in sensor:
                 sensordict['health'] = sensor['health']
             if 'type' in sensor:

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -279,7 +279,8 @@ persistent_ipmicmds = {}
 
 def _dict_sensor(pygreading):
     retdict = {'name': pygreading.name, 'value': pygreading.value,
-               'states': pygreading.states, 'units': pygreading.units,
+               'states': pygreading.states, 'state_ids': pygreading.state_ids,
+               'units': pygreading.units,
                'health': _str_health(pygreading.health),
                'type': pygreading.type,
                }


### PR DESCRIPTION
A plugin may provide a numeric enumeration for
state ids.  Provide that for programmatic recognition
of events in addition to being able to combine the
available text.