### PR TITLE
Add log rotation support

### DIFF
--- a/confluent_server/confluent/config/conf.py
+++ b/confluent_server/confluent/config/conf.py
@@ -1,0 +1,50 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2014 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#This defines config variable to store the global configuration for confluent
+import ConfigParser
+
+_config = None
+
+def init_config():
+    global _config
+    configfile = "/etc/confluent/service.cfg"
+    _config = ConfigParser.ConfigParser()
+    _config.read(configfile)
+
+def get_config():
+    return _config
+
+def get_int_option(section, option):
+    try:
+        return _config.getint(section, option)
+    except (
+    ConfigParser.NoSectionError, ConfigParser.NoOptionError, ValueError):
+        return None
+
+def get_boolean_option(section, option):
+    try:
+        return _config.getboolean(section, option)
+    except (
+    ConfigParser.NoSectionError, ConfigParser.NoOptionError, ValueError):
+        return None
+
+def get_option(section, option):
+    try:
+        return _config.get(section, option)
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+        return None

--- a/confluent_server/confluent/exceptions.py
+++ b/confluent_server/confluent/exceptions.py
@@ -57,3 +57,7 @@ class NotImplementedException(ConfluentException):
     # The current configuration/plugin is unable to perform
     # the requested task. http code 501
     pass
+
+class GlobalConfigError(ConfluentException):
+    # The configuration in the global config file is not right
+    pass

--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -27,6 +27,7 @@
 
 import atexit
 import confluent.auth as auth
+import confluent.config.conf as conf
 import confluent.config.configmanager as configmanager
 import confluent.consoleserver as consoleserver
 import confluent.core as confluentcore
@@ -40,7 +41,6 @@ import fcntl
 import sys
 import os
 import signal
-import ConfigParser
 
 
 def _daemonize():
@@ -126,10 +126,9 @@ def _initsecurity(config):
 
 def run():
     _checkpidfile()
-    configfile = "/etc/confluent/service.cfg"
-    config = ConfigParser.ConfigParser()
-    config.read(configfile)
+    conf.init_config()
     try:
+        config = conf.get_config()
         _initsecurity(config)
     except:
         sys.stderr.write("Error unlocking credential store\n")
@@ -150,8 +149,8 @@ def run():
     #dbgsock = eventlet.listen("/var/run/confluent/dbg.sock",
     #                           family=socket.AF_UNIX)
     #eventlet.spawn_n(backdoor.backdoor_server, dbgsock)
-    http_bind_host, http_bind_port = _get_connector_config(config, 'http')
-    sock_bind_host, sock_bind_port = _get_connector_config(config, 'socket')
+    http_bind_host, http_bind_port = _get_connector_config('http')
+    sock_bind_host, sock_bind_port = _get_connector_config('socket')
     consoleserver.start_console_sessions()
     webservice = httpapi.HttpApi(http_bind_host, http_bind_port)
     webservice.start()
@@ -161,12 +160,7 @@ def run():
     while 1:
         eventlet.sleep(100)
 
-
-def _get_connector_config(config, session):
-    try:
-        host = config.get(session, 'bindhost')
-        port = config.getint(session, 'bindport')
-    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as e:
-        host = None
-        port = None
+def _get_connector_config(session):
+    host = conf.get_option(session, 'bindhost')
+    port = conf.get_int_option(session, 'bindport')
     return (host, port)


### PR DESCRIPTION
Add log rotation support

Add TimedAndSizeRotatingFileHandler which mixes together
the RotatingFileHandler and TimedRotatingFileHandler from
python logging module to process the log data.

Add logrollover event to track the renamed information, so
that console session can read the log data from current log
file and last renamed file.

Global configuration is used by the log handler. The format
of the log section in '/etc/confluent/service.cfg' is like:
[log]
when = m 
backup_count = 3
max_bytes = 8192 
utc = False
