### PR TITLE
Fix erroneous data injection to log replay

### DIFF
--- a/confluent_server/confluent/log.py
+++ b/confluent_server/confluent/log.py
@@ -633,6 +633,9 @@ class Logger(object):
                 flock(binfile, LOCK_SH)
                 binfile.seek(0, 2)
                 binidx = binfile.tell()
+                # things have been set up for next iteration to dig to
+                # previous log file, go to next iteration
+                continue
             elif ltype != 2:
                 continue
             if tstamp > recenttimestamp:


### PR DESCRIPTION
When a rollover event was detected, the offset
of the rollover event itself was being read
from the rolled file erroneously.  Skip to
next loop iteration so that the metadata about
the rollover event is properly ignored in building
the text data buffer.