### PR TITLE
Fix valid noderange character

### DIFF
--- a/confluent_server/confluent/noderange.py
+++ b/confluent_server/confluent/noderange.py
@@ -25,7 +25,7 @@ import pyparsing as pp
 import re
 
 # construct custom grammar with pyparsing
-_nodeword = pp.Word(pp.alphanums + '~^$/=-:.*+!')
+_nodeword = pp.Word(pp.alphanums + '~^$/=-_:.*+!')
 _nodebracket = pp.QuotedString(quoteChar='[', endQuoteChar=']',
                                unquoteResults=False)
 _nodeatom = pp.Group(pp.OneOrMore(_nodeword | _nodebracket))


### PR DESCRIPTION
Underscore should be considered valid (since group names are allowed to have _)