### PR TITLE
Have confluent client do default path

### DIFF
--- a/confluent_client/MANIFEST.in
+++ b/confluent_client/MANIFEST.in
@@ -1,0 +1,1 @@
+include confluent_env.sh

--- a/confluent_client/confluent_env.sh
+++ b/confluent_client/confluent_env.sh
@@ -1,0 +1,2 @@
+PATH=/opt/confluent/bin:$PATH
+export PATH

--- a/confluent_client/setup.py.tmpl
+++ b/confluent_client/setup.py.tmpl
@@ -8,4 +8,5 @@ setup(
     url='http://xcat.sf.net/',
     packages=['confluent'],
     scripts=['bin/confetty', 'bin/nodehealth', 'bin/nodeidentify', 'bin/nodepower', 'bin/nodesensors', 'bin/nodesetboot'],
+    data_files=[('/etc/profile.d', ['confluent_env.sh'])],
 )


### PR DESCRIPTION
When installing package, put a profile.d change
such that confluent is in the default path.