### PR TITLE
Fix pid file behavior on exit

### DIFF
--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -121,7 +121,7 @@ def terminate(signalname, frame):
 
 
 def doexit():
-    if havefcntl:
+    if not havefcntl:
         return
     pidfile = open('/var/run/confluent/pid')
     pid = pidfile.read()


### PR DESCRIPTION
Previous change failed to correct the sense of the 'doexit'
function.