### PR TITLE
Prevent hang on systemctl stop confluent

### DIFF
--- a/confluent_server/systemd/confluent.service
+++ b/confluent_server/systemd/confluent.service
@@ -6,6 +6,7 @@ Description=Confluent hardware manager
 Type=forking
 PIDFile=/var/run/confluent/pid
 ExecStart=/opt/confluent/bin/confluent
+ExecStop=/opt/confluent/bin/confetty shutdown /
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd's default stop seems to be incapable of understanding
how to shut down our service.  Provide an explicit ExecStop
to have systemd act more sanely.