### PR TITLE
Force 'databynode' to consistently be an array

### DIFF
--- a/confluent_server/confluent/httpapi.py
+++ b/confluent_server/confluent/httpapi.py
@@ -537,7 +537,13 @@ def _assemble_json(responses, resource, url, extension):
                     else:
                         rspdata[dk] = [rspdata[dk], rsp[dk]]
                 else:
-                    rspdata[dk] = rsp[dk]
+                    if dk == 'databynode':
+                        # a quirk, databynode suggests noderange
+                        # multi response.  This should *always* be a list,
+                        # even if it will be length 1
+                        rspdata[dk] = [rsp[dk]]
+                    else:
+                        rspdata[dk] = rsp[dk]
     rspdata["_links"] = links
     tlvdata.unicode_dictvalues(rspdata)
     yield json.dumps(


### PR DESCRIPTION
If only one node was in given noderange, then
the httpapi response would not look similar in
structure to a multi-node response.  Force even
single items in this special case to be an array
to allow easier javascript client code.