### PR TITLE
Remove hard require of PyPAM

### DIFF
--- a/confluent_server/confluent_server.spec.tmpl
+++ b/confluent_server/confluent_server.spec.tmpl
@@ -12,7 +12,7 @@ Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}
 BuildArch: noarch
-Requires: pyghmi, eventlet, greenlet, pycrypto >= 2.6.1, confluent_client, PyPAM, pyparsing
+Requires: pyghmi, eventlet, greenlet, pycrypto >= 2.6.1, confluent_client, pyparsing
 Vendor: Jarrod Johnson <jjohnson2@lenovo.com>
 Url: http://xcat.sf.net/
 


### PR DESCRIPTION
Since PAM support is not a mandatory feature,
do not make it required to install.