### PR TITLE
No longer break when prompting for name/password

### DIFF
--- a/confluent_client/bin/confetty
+++ b/confluent_client/bin/confetty
@@ -601,7 +601,6 @@ def server_connect():
         session.authenticate(username, passphrase)
     while not session.authenticated:
         username = raw_input("Name: ")
-        readline.clear_history()
         passphrase = getpass.getpass("Passphrase: ")
         session.authenticate(username, passphrase)
 


### PR DESCRIPTION
In the confetty CLI, readline clear history was done as
part of login process.  Since readline is not a given
to accomodate scripting behaviors, no longer do the
clear_history().  The concern I had was that
the password might have gotten into history, but that
seems to not be the case.