### PR TITLE
Protect against stale data in new requests

### DIFF
--- a/confluent_client/confluent/client.py
+++ b/confluent_client/confluent/client.py
@@ -234,7 +234,6 @@ def send_request(operation, path, server, parameters=None):
         # their unused data
         result = tlvdata.recv(server)
         while '_requestdone' not in result:
-            yield result
             result = tlvdata.recv(server)
     inflight = True
     payload = {'operation': operation, 'path': path}


### PR DESCRIPTION
If a caller (reasonably) broke out of a loop, a subsequent call would get old data.
Protect against this by discarding data not consumed if previously called.