### PR TITLE
Change the stdout/stderr/trace logs to not buffer things over time

### DIFF
--- a/confluent_server/confluent/log.py
+++ b/confluent_server/confluent/log.py
@@ -505,11 +505,12 @@ class Logger(object):
         else:
             return object.__new__(cls)
 
-    def __init__(self, logname, console=False, tenant=None):
+    def __init__(self, logname, console=False, tenant=None, buffered=True):
         if hasattr(self, 'initialized'):
             # we are just a copy of the same object
             return
         self.initialized = True
+        self.buffered = buffered
         self.filepath = confluent.config.configmanager.get_global("logdirectory")
         if self.filepath is None:
             if os.name == 'nt':
@@ -727,8 +728,11 @@ class Logger(object):
         else:
             self.logentries.append(
                 [ltype, timestamp, logdata, event, eventdata])
-        if self.writer is None:
-            self.writer = eventlet.spawn_after(2, self.writedata)
+        if self.buffered:
+            if self.writer is None:
+                self.writer = eventlet.spawn_after(2, self.writedata)
+        else:
+            self.writedata()
 
     def closelog(self):
         self.handler.close()
@@ -746,6 +750,6 @@ def log(logdata=None, ltype=None, event=0, eventdata=None):
 def logtrace():
     global tracelog
     if tracelog is None:
-        tracelog = Logger('trace')
+        tracelog = Logger('trace', buffered=False)
     tracelog.log(traceback.format_exc(), ltype=DataTypes.event,
                  event=Events.stacktrace)

--- a/confluent_server/confluent/log.py
+++ b/confluent_server/confluent/log.py
@@ -494,7 +494,7 @@ class Logger(object):
                      False, events will be formatted like syslog:
                      date: message<CR>
     """
-    def __new__(cls, logname, console=False, tenant=None):
+    def __new__(cls, logname, console=False, tenant=None, buffered=True):
         global _loggers
         if console:
             relpath = 'consoles/' + logname

--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -77,8 +77,8 @@ def _daemonize():
     os.open(os.devnull, os.O_RDWR)
     os.dup2(0, 1)
     os.dup2(0, 2)
-    sys.stdout = log.Logger('stdout')
-    sys.stderr = log.Logger('stderr')
+    sys.stdout = log.Logger('stdout', buffered=False)
+    sys.stderr = log.Logger('stderr', buffered=False)
 
 
 def _updatepidfile():


### PR DESCRIPTION
If something went completely off the rails, it could easily fill up lots of memory with log entries in the 2 seconds it
would buffer.  For now disable the buffering on key debug logs, as the main purpose was reducing IOPs in the per-node
console logs anyway.  A future behavior may be to also limit the size and/or number of outstanding log entries before
committing to disk.