### PR TITLE
Add a recourse to drain queue

### DIFF
--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -290,6 +290,15 @@ def perform_requests(operator, nodes, element, cfg, inputdata):
         for t in list(livingthreads):
             if t.dead:
                 livingthreads.discard(t)
+    try:
+        # drain queue if a thread put something on the queue and died
+        while True:
+            datum = resultdata.get_nowait()
+            if datum != 'Done':
+                yield datum
+    except queue.Empty:
+        pass
+
 
 
 def perform_request(operator, node, element,


### PR DESCRIPTION
While it may not have been possible in eventlet for this to happen,
strictly speaking if it were a thread, it could exit during check for
liveness and leave data on the queue.

To be careful, also drain the queue after all children dead.