### PR TITLE
Update nodeconsole -w to work with arbitrary terminal types

### DIFF
--- a/confluent_client/bin/nodeconsole
+++ b/confluent_client/bin/nodeconsole
@@ -39,7 +39,25 @@ argparser.add_option('-t', '--tile', action='store_true', default=False,
 argparser.add_option('-l', '--log', action='store_true', default=False,
                      help='Enter log replay mode instead of showing a live console')
 argparser.add_option('-w','--windowed', action='store_true', default=False,
-                     help='Open terminal windows for each node.  The environment variable NODECONSOLE_WINDOWED_COMMAND must be set, which should be a text string corresponding to a command that can be used to open a windowed console, omitting the "nodeconsole <noderange>" part of the command, for example, to open a set of consoles for a range of nodes in separate xterm windows, set NODECONSOLE_WINDOWED_COMMAND to "xterm -e", or in a WSL environment, to open a set of consoles for a range of nodes in separate Windows Terminal windows, with the title set for each node, set NODECONSOLE_WINDOWED_COMMAND to "wt.exe --title node wsl.exe -d AlmaLinux-8 --shell-type login".  Note that "node" when in the NODECONSOLE_WINDOWED_COMMAND environment variable is treated as a keyword, not a literal.')
+                     help='Open terminal windows for each node.  The '
+                          'environment variable NODECONSOLE_WINDOWED_COMMAND '
+                          'must be set, which should be a text string corresponding '
+                          'to a command that can be used to open a windowed console,'
+                          ' omitting the "nodeconsole <noderange>" part of the '
+                          'command, for example, to open a set of consoles for a '
+                          'range of nodes in separate xterm windows, set '
+                          'NODECONSOLE_WINDOWED_COMMAND to "xterm -e".  To open a '
+                          'set of consoles for a range of nodes in separate '
+                          'GNOME Terminal windows with a size of 100 columns and '
+                          '31 rows, set NODECONSOLE_WINDOWED_COMMAND '
+                          'to "gnome-terminal --geometry 100x31 --" or in a WSL '
+                          'environment, to open a set of consoles for a range of '
+                          'nodes in separate Windows Terminal windows, with the '
+                          'title set for each node, set NODECONSOLE_WINDOWED_COMMAND'
+                          ' to "wt.exe --title node wsl.exe -d AlmaLinux-8 '
+                          '--shell-type login".  Note that "node" when in the '
+                          'NODECONSOLE_WINDOWED_COMMAND environment variable is '
+                          'treated as a keyword, not a literal.')
 (options, args) = argparser.parse_args()
 if len(args) != 1:
     argparser.print_help()
@@ -55,6 +73,10 @@ if options.log:
     sys.exit(0)
 #added functionality for wcons
 if options.windowed:
+    envstring=os.environ.get('NODECONSOLE_WINDOWED_COMMAND')
+    if not envstring:
+        print("NODECONSOLE_WINDOWED_COMMAND not defined and -w specified.  Exiting...\n")
+        sys.exit(1)
     envlist=os.environ.get('NODECONSOLE_WINDOWED_COMMAND').split(' ')
     nodes = []
     sess = client.Command()

--- a/confluent_client/bin/nodeconsole
+++ b/confluent_client/bin/nodeconsole
@@ -54,10 +54,8 @@ argparser.add_option('-w','--windowed', action='store_true', default=False,
                           'environment, to open a set of consoles for a range of '
                           'nodes in separate Windows Terminal windows, with the '
                           'title set for each node, set NODECONSOLE_WINDOWED_COMMAND'
-                          ' to "wt.exe --title node wsl.exe -d AlmaLinux-8 '
-                          '--shell-type login".  Note that "node" when in the '
-                          'NODECONSOLE_WINDOWED_COMMAND environment variable is '
-                          'treated as a keyword, not a literal.')
+                          ' to "wt.exe wsl.exe -d AlmaLinux-8 '
+                          '--shell-type login".')
 (options, args) = argparser.parse_args()
 if len(args) != 1:
     argparser.print_help()
@@ -86,12 +84,9 @@ if options.windowed:
             sys.stderr.write(res.get('error', repr(res)) + '\n')
             sys.exit(1)
         nodes.append(node)
-    # Hack to deal with messed up terminal after starting wt.exe using subprocess.Popen in WSL - AHW 10/15/22
-    sttyg = subprocess.run(['stty', '-g'], stdout=subprocess.PIPE, universal_newlines=True)
     for node in sortutil.natural_sort(nodes):
-        subprocess.Popen(envlist + [confettypath, '-m', '5', 'start', '/nodes/{0}/console/session'.format(node)])
-    # Hack to deal with messed up terminal after starting wt.exe using subprocess.Popen in WSL - AHW 10/15/22
-    subprocess.run(['stty', '{0}'.format(sttyg.stdout.strip("\n"))])
+        with open(os.devnull, 'wb') as devnull:
+            subprocess.Popen(envlist + [confettypath, '-m', '5', 'start', '/nodes/{0}/console/session'.format(node)], stdin=devnull)
     sys.exit(0)
 #end of wcons
 if options.tile:

--- a/confluent_client/bin/nodeconsole
+++ b/confluent_client/bin/nodeconsole
@@ -41,7 +41,7 @@ argparser.add_option('-l', '--log', action='store_true', default=False,
 argparser.add_option('-w','--windowed', action='store_true', default=False,
                      help='Open terminal windows for each node.  The '
                           'environment variable NODECONSOLE_WINDOWED_COMMAND '
-                          'must be set, which should be a text string corresponding '
+                          'should be set, which should be a text string corresponding '
                           'to a command that can be used to open a windowed console,'
                           ' omitting the "nodeconsole <noderange>" part of the '
                           'command, for example, to open a set of consoles for a '
@@ -55,7 +55,9 @@ argparser.add_option('-w','--windowed', action='store_true', default=False,
                           'nodes in separate Windows Terminal windows, with the '
                           'title set for each node, set NODECONSOLE_WINDOWED_COMMAND'
                           ' to "wt.exe wsl.exe -d AlmaLinux-8 '
-                          '--shell-type login".')
+                          '--shell-type login".  If the NODECONSOLE_WINDOWED_COMMAND '
+                          'environment variable isn\'t set, xterm will be used by'
+                          'default.')
 (options, args) = argparser.parse_args()
 if len(args) != 1:
     argparser.print_help()
@@ -73,9 +75,9 @@ if options.log:
 if options.windowed:
     envstring=os.environ.get('NODECONSOLE_WINDOWED_COMMAND')
     if not envstring:
-        print("NODECONSOLE_WINDOWED_COMMAND not defined and -w specified.  Exiting...\n")
-        sys.exit(1)
-    envlist=os.environ.get('NODECONSOLE_WINDOWED_COMMAND').split(' ')
+        envlist=["xterm", "-e"]
+    else:
+        envlist=os.environ.get('NODECONSOLE_WINDOWED_COMMAND').split(' ')
     nodes = []
     sess = client.Command()
     for res in sess.read('/noderange/{0}/nodes/'.format(args[0])):

--- a/confluent_client/bin/nodeconsole
+++ b/confluent_client/bin/nodeconsole
@@ -39,7 +39,7 @@ argparser.add_option('-t', '--tile', action='store_true', default=False,
 argparser.add_option('-l', '--log', action='store_true', default=False,
                      help='Enter log replay mode instead of showing a live console')
 argparser.add_option('-w','--windowed', action='store_true', default=False,
-                     help='Open terminal windows for each node')
+                     help='Open terminal windows for each node.  The environment variable NODECONSOLE_WINDOWED_COMMAND must be set, which should be a text string corresponding to a command that can be used to open a windowed console, omitting the "nodeconsole <noderange>" part of the command, for example, to open a set of consoles for a range of nodes in separate xterm windows, set NODECONSOLE_WINDOWED_COMMAND to "xterm -e", or in a WSL environment, to open a set of consoles for a range of nodes in separate Windows Terminal windows, with the title set for each node, set NODECONSOLE_WINDOWED_COMMAND to "wt.exe --title node wsl.exe -d AlmaLinux-8 --shell-type login".  Note that "node" when in the NODECONSOLE_WINDOWED_COMMAND environment variable is treated as a keyword, not a literal.')
 (options, args) = argparser.parse_args()
 if len(args) != 1:
     argparser.print_help()
@@ -55,6 +55,7 @@ if options.log:
     sys.exit(0)
 #added functionality for wcons
 if options.windowed:
+    envlist=os.environ.get('NODECONSOLE_WINDOWED_COMMAND').split(' ')
     nodes = []
     sess = client.Command()
     for res in sess.read('/noderange/{0}/nodes/'.format(args[0])):
@@ -63,9 +64,13 @@ if options.windowed:
             sys.stderr.write(res.get('error', repr(res)) + '\n')
             sys.exit(1)
         nodes.append(node)
+    # Hack to deal with messed up terminal after starting wt.exe using subprocess.Popen in WSL - AHW 10/15/22
+    sttyg = subprocess.run(['stty', '-g'], stdout=subprocess.PIPE, universal_newlines=True)
     for node in sortutil.natural_sort(nodes):
-        sub = subprocess.Popen(['xterm', '-e', 'nodeconsole', node])
-        out,err = sub.communicate()
+        subprocess.Popen(envlist + [confettypath, '-m', '5', 'start', '/nodes/{0}/console/session'.format(node)])
+    # Hack to deal with messed up terminal after starting wt.exe using subprocess.Popen in WSL - AHW 10/15/22
+    subprocess.run(['stty', '{0}'.format(sttyg.stdout.strip("\n"))])
+    sys.exit(0)
 #end of wcons
 if options.tile:
     null = open('/dev/null', 'w')

--- a/confluent_client/doc/man/nodeconsole.ronn
+++ b/confluent_client/doc/man/nodeconsole.ronn
@@ -43,10 +43,8 @@ a new session.
   environment, to open a set of consoles for a range of
   nodes in separate Windows Terminal windows, with the
   title set for each node, set **NODECONSOLE_WINDOWED_COMMAND**
-  to `wt.exe --title node wsl.exe -d AlmaLinux-8
-  --shell-type login`.  Note that **"node"** when in the
-  NODECONSOLE_WINDOWED_COMMAND environment variable is
-  treated as a keyword, not a literal.
+  to `wt.exe wsl.exe -d AlmaLinux-8
+  --shell-type login`.
 
 ## ESCAPE SEQUENCE COMMANDS
 

--- a/confluent_client/doc/man/nodeconsole.ronn
+++ b/confluent_client/doc/man/nodeconsole.ronn
@@ -30,7 +30,7 @@ a new session.
 * `-w`, `--windowed`:
   Open terminal windows for each node.  The
   environment variable **NODECONSOLE_WINDOWED_COMMAND**
-  must be set, which should be a text string corresponding
+  should be set, which should be a text string corresponding
   to a command that can be used to open a windowed console,
   omitting the `nodeconsole <noderange>` part of the
   command, for example, to open a set of consoles for a
@@ -43,8 +43,9 @@ a new session.
   environment, to open a set of consoles for a range of
   nodes in separate Windows Terminal windows, with the
   title set for each node, set **NODECONSOLE_WINDOWED_COMMAND**
-  to `wt.exe wsl.exe -d AlmaLinux-8
-  --shell-type login`.
+  to `wt.exe wsl.exe -d AlmaLinux-8 --shell-type login.  If the
+  NODECONSOLE_WINDOWED_COMMAND environment variable isn't set,
+  xterm will be used bydefault.
 
 ## ESCAPE SEQUENCE COMMANDS
 

--- a/confluent_client/doc/man/nodeconsole.ronn
+++ b/confluent_client/doc/man/nodeconsole.ronn
@@ -28,17 +28,25 @@ a new session.
   manager at this time.
   
 * `-w`, `--windowed`:
-  Open terminal windows for each node.  The environment variable
-  NODECONSOLE_WINDOWED_COMMAND must be set, which should be a text string
-  corresponding to a command that can be used to open a windowed console,
-  omitting the "nodeconsole <noderange>" part of the command, for example, to
-  open a set of consoles for a range of nodes in separate xterm windows, set
-  NODECONSOLE_WINDOWED_COMMAND to "xterm -e", or in a WSL environment, to open
-  a set of consoles for a range of nodes in separate Windows Terminal windows,
-  with the title set for each node, set NODECONSOLE_WINDOWED_COMMAND to "wt.exe
-  --title node wsl.exe -d AlmaLinux-8 --shell-type login".  Note that "node" when
-  in the NODECONSOLE_WINDOWED_COMMAND environment variable is treated as a keyword,
-  not a literal.
+  Open terminal windows for each node.  The
+  environment variable **NODECONSOLE_WINDOWED_COMMAND**
+  must be set, which should be a text string corresponding
+  to a command that can be used to open a windowed console,
+  omitting the `nodeconsole <noderange>` part of the
+  command, for example, to open a set of consoles for a
+  range of nodes in separate xterm windows, set
+  **NODECONSOLE_WINDOWED_COMMAND** to `xterm -e`.  To open a
+  set of consoles for a range of nodes in separate
+  GNOME Terminal windows with a size of 100 columns and
+  31 rows, set **NODECONSOLE_WINDOWED_COMMAND**
+  to `gnome-terminal --geometry 100x31 --` or in a WSL
+  environment, to open a set of consoles for a range of
+  nodes in separate Windows Terminal windows, with the
+  title set for each node, set **NODECONSOLE_WINDOWED_COMMAND**
+  to `wt.exe --title node wsl.exe -d AlmaLinux-8
+  --shell-type login`.  Note that **"node"** when in the
+  NODECONSOLE_WINDOWED_COMMAND environment variable is
+  treated as a keyword, not a literal.
 
 ## ESCAPE SEQUENCE COMMANDS
 

--- a/confluent_client/doc/man/nodeconsole.ronn
+++ b/confluent_client/doc/man/nodeconsole.ronn
@@ -28,8 +28,17 @@ a new session.
   manager at this time.
   
 * `-w`, `--windowed`:
-  Openes separate xterm windows for each console in the node range provided. This 
-  works for xterm only.
+  Open terminal windows for each node.  The environment variable
+  NODECONSOLE_WINDOWED_COMMAND must be set, which should be a text string
+  corresponding to a command that can be used to open a windowed console,
+  omitting the "nodeconsole <noderange>" part of the command, for example, to
+  open a set of consoles for a range of nodes in separate xterm windows, set
+  NODECONSOLE_WINDOWED_COMMAND to "xterm -e", or in a WSL environment, to open
+  a set of consoles for a range of nodes in separate Windows Terminal windows,
+  with the title set for each node, set NODECONSOLE_WINDOWED_COMMAND to "wt.exe
+  --title node wsl.exe -d AlmaLinux-8 --shell-type login".  Note that "node" when
+  in the NODECONSOLE_WINDOWED_COMMAND environment variable is treated as a keyword,
+  not a literal.
 
 ## ESCAPE SEQUENCE COMMANDS
 


### PR DESCRIPTION
[Update nodeconsole -w to work with arbitrary terminal types](https://github.com/xcat2/confluent/commit/2c58320f326e9af9e1d7c79792a32cf5152f5aad)