### PR TITLE
nodeeventlog: return last n entries

### DIFF
--- a/confluent_client/bin/nodeeventlog
+++ b/confluent_client/bin/nodeeventlog
@@ -121,7 +121,7 @@ for rsp in func('/noderange/{0}/events/hardware/log'.format(noderange)):
             if 'events' in thisdata:
                 evtdata = thisdata['events']
                 if options.lines:
-                    event_dict[node].append(evtdata)
+                    event_dict[node].extend(evtdata)
                 else:
                     for evt in evtdata:
                         print('{0}: {1}'.format(node, format_event(evt)))
@@ -130,8 +130,8 @@ if options.lines:
     for node in nodes:
         evtdata_list = event_dict[node]
         if len(evtdata_list) != 0:
-            evtdata = evtdata_list[-1]
-            if len(evtdata) > options.lines:
-                evtdata = evtdata[-abs(options.lines):]
-            for evt in evtdata:
+            if len(evtdata_list) > options.lines:
+                evtdata_list = evtdata_list[-abs(options.lines):]
+            for evt in evtdata_list:
                 print('{0}: {1}'.format(node, format_event(evt)))
+                

--- a/confluent_client/bin/nodeeventlog
+++ b/confluent_client/bin/nodeeventlog
@@ -41,7 +41,11 @@ argparser = optparse.OptionParser(
 argparser.add_option('-m', '--maxnodes', type='int',
                      help='Specify a maximum number of '
                           'nodes to clear if clearing log, '
-                          'prompting if over the threshold')            
+                          'prompting if over the threshold')   
+argparser.add_option('-l', '--lines', type='int',
+                     help='return the last <n> entries  '
+                          'for each node in the eventlog. '
+                          )           
 (options, args) = argparser.parse_args()
 try:
     noderange = args[0]
@@ -95,6 +99,14 @@ if deletemode:
     session.stop_if_noderange_over(noderange, options.maxnodes)
 else:
     func = session.read
+
+event_dict = {}
+nodes = []
+for res in session.read('/noderange/{0}/nodes/'.format(args[0])):
+    node = res.get('item', {}).get('href', '/').replace('/', '')
+    nodes.append(node)
+    event_dict[node] = []
+
 for rsp in func('/noderange/{0}/events/hardware/log'.format(noderange)):
     if 'error' in rsp:
         sys.stderr.write(rsp['error'] + '\n')
@@ -107,6 +119,19 @@ for rsp in func('/noderange/{0}/events/hardware/log'.format(noderange)):
                sys.stderr.write('{0}: {1}\n'.format(node, thisdata['error']))
                exitcode |= 1
             if 'events' in thisdata:
-               evtdata = thisdata['events']
-               for evt in evtdata:
-                   print('{0}: {1}'.format(node, format_event(evt)))
+                evtdata = thisdata['events']
+                if options.lines:
+                    event_dict[node].append(evtdata)
+                else:
+                    for evt in evtdata:
+                        print('{0}: {1}'.format(node, format_event(evt)))
+
+if options.lines:
+    for node in nodes:
+        evtdata_list = event_dict[node]
+        if len(evtdata_list) != 0:
+            evtdata = evtdata_list[-1]
+            if len(evtdata) > options.lines:
+                evtdata = evtdata[-abs(options.lines):]
+            for evt in evtdata:
+                print('{0}: {1}'.format(node, format_event(evt)))


### PR DESCRIPTION
made it possible to specify the number of lines nodeeventlog returns for each node 
``` nodeeventlog -l <n> <noderange>```