### PR TITLE
node rsync -s switch

### DIFF
--- a/confluent_client/bin/nodersync
+++ b/confluent_client/bin/nodersync
@@ -72,7 +72,9 @@ def run():
     elif options.substitutename and not options.loginname:
         subname = options.substitutename
         if '{' not in subname:
-            cmdstr += ' {node}' + '{}:'.format(options.substitutename)  + targpath
+            cmdstr += ' {node}' + '{}:'.format(subname)  + targpath
+        else:
+            cmdstr += ' {}:'.format(subname) + targpath
     else:
         cmdstr += ' {node}:' + targpath
 

--- a/confluent_client/bin/nodersync
+++ b/confluent_client/bin/nodersync
@@ -65,18 +65,20 @@ def run():
     c = client.Command()
     cmdstr = ' '.join(args[:-1])
     cmdstr = 'rsync -av --info=progress2 ' + cmdstr
-    if options.loginname and options.substitutename: 
-        cmdstr += ' {}@'.format(options.loginname) + '{node}' + '{}:'.format(options.substitutename) + targpath
-    elif options.loginname and not options.substitutename:
-        cmdstr += ' {}@'.format(options.loginname) + '{node}:' + targpath  
-    elif options.substitutename and not options.loginname:
-        subname = options.substitutename
-        if '{' not in subname:
-            cmdstr += ' {node}' + '{}:'.format(subname)  + targpath
-        else:
-            cmdstr += ' {}:'.format(subname) + targpath
+    
+    targname = options.substitutename
+    if targname and '{' in targname:
+        targname =  targname + ':'
+    elif targname:
+        targname = '{node}' + targname + ':'
     else:
-        cmdstr += ' {node}:' + targpath
+        targname = '{node}:'
+
+    if options.loginname:
+        cmdstr += ' {}@'.format(options.loginname) + targname + targpath
+    else:
+        cmdstr += ' {}'.format(targname) + targpath
+    
 
     currprocs = 0
     all = set([])

--- a/confluent_client/bin/nodersync
+++ b/confluent_client/bin/nodersync
@@ -48,6 +48,8 @@ def run():
                           'prompting if over the threshold')   
     argparser.add_option('-l', '--loginname', type='str',
                          help='Username to use when connecting, defaults to current user.')
+    argparser.add_option('-s', '--substitutename',
+                         help='Use a different name other than the nodename for rsync')
     argparser.add_option('-f', '-c', '--count', type='int', default=168,
                          help='Number of nodes to concurrently rsync')
     # among other things, FD_SETSIZE limits.  Besides, spawning too many
@@ -63,8 +65,14 @@ def run():
     c = client.Command()
     cmdstr = ' '.join(args[:-1])
     cmdstr = 'rsync -av --info=progress2 ' + cmdstr
-    if options.loginname:
-        cmdstr += ' {}@'.format(options.loginname) + '{node}:' + targpath
+    if options.loginname and options.substitutename: 
+        cmdstr += ' {}@'.format(options.loginname) + '{node}' + '{}:'.format(options.substitutename) + targpath
+    elif options.loginname and not options.substitutename:
+        cmdstr += ' {}@'.format(options.loginname) + '{node}:' + targpath  
+    elif options.substitutename and not options.loginname:
+        subname = options.substitutename
+        if '{' not in subname:
+            cmdstr += ' {node}' + '{}:'.format(options.substitutename)  + targpath
     else:
         cmdstr += ' {node}:' + targpath
 

--- a/confluent_client/doc/man/nodersync.ronn
+++ b/confluent_client/doc/man/nodersync.ronn
@@ -16,6 +16,9 @@ noderange. This will present progress as percentage for all nodes.
   Specify how many rsync executions to do concurrently.  If noderange
   exceeds the count, then excess nodes will wait until one of the
   active count completes. 
+
+* `-s`, `--substitutename`:
+  'Use a different name other than the nodename for rsync'
   
 * `-m MAXNODES`, `--maxnodes=MAXNODES`:
   Specify a maximum number of nodes to run rsync to, prompting if over the


### PR DESCRIPTION
Allows you to be able to specify a subname to be used in rsync

- `nodersync -s -enet1 src_file n1:dest_folder`

this will be resolved and the resulting arg to be run with rsync is 

- rsync -av --info=progress2 src_file  `n1-enet`:dest_folder`

This also works for when specifying both loginname and subname 

- `nodersync -s -enet1 -l user1 src_file n1:dest_folder`

this will be : 

-  rsync -av --info=progress2 src_file  `user1@n1-enet`:dest_folder`

