### PR TITLE
disable online repos for openSUSE leap

### DIFF
--- a/confluent_osdeploy/suse15/profiles/hpc/autoyast.leap
+++ b/confluent_osdeploy/suse15/profiles/hpc/autoyast.leap
@@ -10,6 +10,12 @@ dynamic behavior and replace with static configuration.
       <hwclock>UTC</hwclock>
       <timezone>%%TIMEZONE%%</timezone>
     </timezone>
+    <firstboot>
+      <firstboot_enabled config:type="boolean">false</firstboot_enabled>
+    </firstboot>
+    <kdump>
+      <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    </kdump>
     <general>
       <self_update config:type="boolean">false</self_update>
       <mode>

--- a/confluent_osdeploy/suse15/profiles/hpc/initprofile.sh
+++ b/confluent_osdeploy/suse15/profiles/hpc/initprofile.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# WARNING
+# be careful when editing files here as this script is called
+# in parallel to other copy operations, so changes to files can be lost
 discnum=$(basename $1)
 if [ "$discnum" != 1 ]; then exit 0; fi
 if [ -e $2/boot/kernel ]; then exit 0; fi

--- a/confluent_osdeploy/suse15/profiles/hpc/scripts/post.d/10-remove-online-repos.sh
+++ b/confluent_osdeploy/suse15/profiles/hpc/scripts/post.d/10-remove-online-repos.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+# remove online repos
+grep -lE "baseurl=https?://download.opensuse.org" /etc/zypp/repos.d/*repo | xargs rm --

--- a/confluent_osdeploy/suse15/profiles/server/autoyast.leap
+++ b/confluent_osdeploy/suse15/profiles/server/autoyast.leap
@@ -10,6 +10,12 @@ dynamic behavior and replace with static configuration.
       <hwclock>UTC</hwclock>
       <timezone>%%TIMEZONE%%</timezone>
     </timezone>
+    <firstboot>
+      <firstboot_enabled config:type="boolean">false</firstboot_enabled>
+    </firstboot>
+    <kdump>
+      <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    </kdump>
     <general>
       <self_update config:type="boolean">false</self_update>
       <mode>

--- a/confluent_osdeploy/suse15/profiles/server/initprofile.sh
+++ b/confluent_osdeploy/suse15/profiles/server/initprofile.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# WARNING
+# be careful when editing files here as this script is called
+# in parallel to other copy operations, so changes to files can be lost
 discnum=$(basename $1)
 if [ "$discnum" != 1 ]; then exit 0; fi
 if [ -e $2/boot/kernel ]; then exit 0; fi

--- a/confluent_osdeploy/suse15/profiles/server/scripts/post.d/10-remove-online-repos.sh
+++ b/confluent_osdeploy/suse15/profiles/server/scripts/post.d/10-remove-online-repos.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+# remove online repos
+grep -lE "baseurl=https?://download.opensuse.org" /etc/zypp/repos.d/*repo | xargs rm --


### PR DESCRIPTION
online repositories may not be accesible for the cluster
nodes but were added from the content.xml. Editing this
files with initprofile.sh is impossible as they are executed
in parallel, so all repos starting with
https?://download.opensuse.org
are removed during post

Signed-off-by: Christian Goll <cgoll@suse.com>
