### PR TITLE
Add default time zone as UTC

### DIFF
--- a/confluent_server/confluent/selfservice.py
+++ b/confluent_server/confluent/selfservice.py
@@ -30,7 +30,7 @@ import eventlet
 webclient = eventlet.import_patched('pyghmi.util.webclient')
 
 
-currtz = None
+currtz = 'UTC'
 keymap = 'us'
 currlocale = 'en_US.UTF-8'
 currtzvintage = None


### PR DESCRIPTION
Add the default timezone to UTC to avoid deployment errors caused by timezone failure