### PR TITLE
Fix efivars handling of unexpected unmount

### DIFF
--- a/confluent_osdeploy/ubuntu20.04/profiles/default/scripts/post.sh
+++ b/confluent_osdeploy/ubuntu20.04/profiles/default/scripts/post.sh
@@ -56,6 +56,7 @@ cp /custom-installation/confluent/bin/apiclient /target/opt/confluent/bin
 mount -o bind /dev /target/dev
 mount -o bind /proc /target/proc
 mount -o bind /sys /target/sys
+mount -o bind /sys/firmware/efi/efivars /target/sys/firmware/efi/efivars
 if [ 1 = $updategrub ]; then
     chroot /target update-grub
 fi

--- a/confluent_osdeploy/ubuntu22.04/profiles/default/scripts/post.sh
+++ b/confluent_osdeploy/ubuntu22.04/profiles/default/scripts/post.sh
@@ -60,6 +60,7 @@ cp /custom-installation/confluent/bin/apiclient /target/opt/confluent/bin
 mount -o bind /dev /target/dev
 mount -o bind /proc /target/proc
 mount -o bind /sys /target/sys
+mount -o bind /sys/firmware/efi/efivars /target/sys/firmware/efi/efivars
 if [ 1 = $updategrub ]; then
     chroot /target update-grub
 fi


### PR DESCRIPTION
Mount efivars in the post.sh script to avoid failure to change the boot order when deploying ubuntu in SE360 v2 due to efivars failure to load