### PR TITLE
Sample postscripts

### DIFF
--- a/confluent_client/bin/nodebmcpassword
+++ b/confluent_client/bin/nodebmcpassword
@@ -1,0 +1,91 @@
+#!/usr/libexec/platform-python
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2015-2017 Lenovo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__author__ = 'tkucherera'
+
+import optparse
+import os
+import signal
+import sys
+try:
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+except AttributeError:
+    pass
+
+path = os.path.dirname(os.path.realpath(__file__))
+path = os.path.realpath(os.path.join(path, '..', 'lib', 'python'))
+if path.startswith('/opt'):
+    sys.path.append(path)
+
+import confluent.client as client
+
+argparser = optparse.OptionParser(usage="Usage: %prog <noderange> <username> <new_password>")
+argparser.add_option('-m', '--maxnodes', type='int',
+                     help='Number of nodes to affect before prompting for confirmation')
+
+
+
+(options, args) = argparser.parse_args()
+try:
+    noderange = args[0]
+    username = args[1]
+    new_password = args[2]
+except IndexError:
+    argparser.print_help()
+    sys.exit(1)
+client.check_globbing(noderange)
+session = client.Command()
+exitcode = 0
+
+
+
+errorNodes = set([])
+
+uid_dict = {}
+session.stop_if_noderange_over(noderange, options.maxnodes)
+
+for rsp in session.read('/noderange/{0}/configuration/management_controller/users/all'.format(noderange)):
+    databynode = rsp["databynode"]
+    for node in databynode:
+        if 'error' in rsp['databynode'][node]:
+            print(node, ':', rsp['databynode'][node]['error'])
+            continue
+        for user in  rsp['databynode'][node]['users']:
+            if user['username'] == username:
+                if not user['uid'] in uid_dict:
+                    uid_dict[user['uid']] = node
+                    continue
+                uid_dict[user['uid']] = uid_dict[user['uid']] + ',{}'.format(node)
+                break
+
+for uid in uid_dict:     
+    success = session.simple_noderange_command(uid_dict[uid], 'configuration/management_controller/users/{0}'.format(uid), new_password, key='password', errnodes=errorNodes)   # = 0 if successful
+
+allNodes = set([])
+
+for node in session.read('/noderange/{0}/nodes/'.format(noderange)):
+    if 'error' in node and success != 0:
+        sys.exit(success)
+    allNodes.add(node['item']['href'].replace("/", ""))
+
+goodNodes = allNodes - errorNodes
+
+for node in goodNodes:
+    print(node + ": Password Change Successful")
+
+
+sys.exit(success)

--- a/confluent_client/doc/man/nodebmcpassword.ronn
+++ b/confluent_client/doc/man/nodebmcpassword.ronn
@@ -1,0 +1,28 @@
+nodebmcpassword(8) -- Change management controller password for a specified user
+=========================================================
+
+## SYNOPSIS
+
+`nodebmcpassword <noderange> <username> <new_password>`  
+
+## DESCRIPTION
+
+`nodebmcpassword` allows you to change the management controller password for a user on a specified noderange
+
+## OPTIONS
+
+* `-m MAXNODES`, `--maxnodes=MAXNODES`:
+  Number of nodes to affect before prompting for
+  confirmation
+  
+* `-h`, `--help`:
+  Show help message and exit  
+
+## EXAMPLES:
+
+* Reset the management controller for nodes n1 through n4:
+  `# nodebmcreset n1-n4`  
+  `n1: Password Change Successful`  
+  `n2: Password Change Successful`  
+  `n3: Password Change Successful`  
+  `n4: Password Change Successful`  

--- a/confluent_osdeploy/common/profile/scripts/samples/consoleredirect
+++ b/confluent_osdeploy/common/profile/scripts/samples/consoleredirect
@@ -1,0 +1,49 @@
+is_suse=false
+is_rhel=false
+
+if test -f /boot/efi/EFI/redhat/grub.cfg; then
+    grubcfg="/boot/efi/EFI/redhat/grub.cfg"
+    grub2-mkconfig -o $grubcfg
+    is_rhel=true
+elif test -f /boot/efi/EFI/sle_hpc/grub.cfg; then
+    grubcfg="/boot/efi/EFI/sle_hpc/grub.cfg"
+    grub2-mkconfig -o $grubcfg
+    is_suse=true
+else
+    echo "Expected File missing: Check if os sle_hpc or redhat"
+    exit
+fi
+
+# working on SUSE
+if $is_suse; then
+    start=false
+    num_line=0
+    lines_to_edit=()
+    while read line; do
+        ((num_line++))
+        if [[ $line == *"grub_platform"* ]]; then
+            start=true
+        fi
+        if $start; then
+            if [[ $line != "#"* ]];then
+                lines_to_edit+=($num_line)
+            fi
+        fi
+        if [[ ${#line} -eq 2 && $line == *"fi" ]]; then
+            if $start; then
+                start=false
+            fi
+        fi
+    done < grub_cnf.cfg
+
+    for line_num in "${lines_to_edit[@]}"; do
+        line_num+="s"
+        sed -i "${line_num},^,#," $grubcfg
+    done
+    sed -i 's,^terminal,#terminal,' $grubcfg
+fi
+
+# Working on Redhat
+if $is_rhel; then
+    sed -i 's,^serial,#serial, ; s,^terminal,#terminal,' $grubcfg
+fi


### PR DESCRIPTION
1. Adding a sample directory where we can add sample scripts for customers.
2.  There is a sample postscript for configuring console redirect on suse15 and el9 servers

```
for targ in %{buildroot}/opt/confluent/lib/osdeploy/$os/profiles/*; do
        cp -a common/profile/* $targ
    done
```
This sample directory would appear in all the oses listed in the /opt/confluent/lib/osdeploy directory (although some of these sample scripts are not common to all oses, they certainly could be helpful when trying to have the same effect on diff os)

