### PR TITLE
Fix EL stateful install

### DIFF
--- a/confluent_osdeploy/el8/profiles/default/scripts/pre.sh
+++ b/confluent_osdeploy/el8/profiles/default/scripts/pre.sh
@@ -115,7 +115,7 @@ grep '^%include /tmp/partitioning' /tmp/kickstart.* > /dev/null || rm /tmp/insta
 if [ -e /tmp/installdisk -a ! -e /tmp/partitioning ]; then
     INSTALLDISK=$(cat /tmp/installdisk)
     sed -e s/%%INSTALLDISK%%/$INSTALLDISK/ -e s/%%LUKSHOOK%%/$LUKSPARTY/ /tmp/partitioning.template > /tmp/partitioning
-    dd if=/dev/zero of=/dev/$(cat /tmp/installdisk) bs=1M count=1 >& /dev/null
     vgchange -a n >& /dev/null
+    wipefs -a -f /dev/$INSTALLDISK >& /dev/null
 fi
 kill $logshowpid


### PR DESCRIPTION
Sometimes stateful install can fail if `vgchange -a n` is run after `dd`.
Use `wipefs` instead and fix order of both commands.
Furthermore, use the `$INSALLDISK` variable.

_Note: This behaviour was observed in an UEFI based VM setup._

Anaconda `/tmp/storage.log` prior change:

```
DEBUG:blivet:action: [194] create format efi filesystem mounted at /boot/efi on partition vda1 (id 190)
INFO:blivet:executing action: [173] destroy format vfat filesystem on partition vda1 (id 33)
DEBUG:blivet:                PartitionDevice.setup: vda1 ; orig: True ; status: False ; controllable: True ;
DEBUG:blivet:                    PartitionDevice.setup_parents: name: vda1 ; orig: True ;
DEBUG:blivet:                      DiskDevice.setup: vda ; orig: True ; status: True ; controllable: True ;
DEBUG:blivet:                      DiskLabel.setup: device: /dev/vda ; type: disklabel ; status: False ;
INFO:program:Running... udevadm settle --timeout=300
DEBUG:program:Return code: 0
DEBUG:blivet:                    PartitionDevice.update_sysfs_path: vda1 ; status: False ;
ERROR:blivet:failed to update sysfs path for vda1: [Errno 2] No such file or directory: '/dev/vda1'
DEBUG:blivet:                          PartitionDevice.read_current_size: exists: True ; path: /dev/vda1 ; sysfs_path:  ;
DEBUG:blivet:updated vda1 size to 0 B (0 B)
INFO:program:Running... udevadm settle --timeout=300
DEBUG:program:Return code: 0
DEBUG:blivet:                FATFS.destroy: device: /dev/vda1 ; type: vfat ; status: False ;
INFO:program:Running... udevadm settle --timeout=300
DEBUG:program:Return code: 0
ERROR:anaconda.modules.storage.installation:Failed to create storage layout: device path does not exist or is not writable
```