### PR TITLE
Use natural sort for lists in json dumps

### DIFF
--- a/confluent_server/confluent/config/configmanager.py
+++ b/confluent_server/confluent/config/configmanager.py
@@ -2647,7 +2647,7 @@ class ConfigManager(object):
                                 dumpdata[confarea][element][attribute]['cryptvalue'] = '!'.join(cryptval)
                     elif isinstance(dumpdata[confarea][element][attribute], set):
                         dumpdata[confarea][element][attribute] = \
-                            list(dumpdata[confarea][element][attribute])
+                            confluent.util.natural_sort(list(dumpdata[confarea][element][attribute]))
         return json.dumps(
             dumpdata, sort_keys=True, indent=4, separators=(',', ': '))
 


### PR DESCRIPTION
Previously, items were randomly arranged in lists in the json dump. This meant that the JSON files were different after each export. Now they are naturally sorted and identical.
This should make it easier to save and compare the JSON dumps in version control systems.

Before (random and different for each export):
```json
            "nodes": [
                "cchassis14",
                "cchassis6",
                "cchassis38",
                "cchassis34",
                "cchassis19",
                "cchassis16",
                "cchassis4",
                "cchassis22",
                "cchassis33",
                "cchassis7",
                "cchassis1",
                "cchassis29",
                ...
            ]

```

After (sorted and identical for each export):
```json
            "nodes": [
                "cchassis1",
                "cchassis2",
                "cchassis3",
                "cchassis4",
                "cchassis5",
                "cchassis6",
                "cchassis7",
                "cchassis8",
                "cchassis9",
                "cchassis10",
                "cchassis11",
                "cchassis12",
                ...
            ]
```
