### PR TITLE
Add VLAN/PKEY support to confignet (fix #157)

### DIFF
--- a/confluent_osdeploy/common/profile/scripts/confignet
+++ b/confluent_osdeploy/common/profile/scripts/confignet
@@ -405,20 +405,35 @@ class NetworkManager(object):
         else:
             cname = stgs.get('connection_name', None)
             iname = list(cfg['interfaces'])[0]
-            if not cname:
-                cname = iname
+            ctype = self.devtypes[iname]
+            if stgs.get('vlan_id', None):
+                vlan = stgs['vlan_id']
+                if ctype == 'infiniband':
+                    vlan = '0x{0}'.format(vlan) if not vlan.startswith('0x') else vlan
+                    cmdargs['infiniband.parent'] = iname
+                    cmdargs['infiniband.p-key'] = vlan
+                    iname = '{0}.{1}'.format(iname, vlan[2:])
+                    cname = iname if not cname else cname
+                elif ctype == 'ethernet':
+                    ctype = 'vlan'
+                    cmdargs['vlan.parent'] = iname
+                    cmdargs['vlan.id'] = vlan
+                    iname = '{0}.{1}'.format(iname, vlan)
+                    cname = iname if not cname else cname
+                else:
+                    sys.stderr.write("Warning, unknown interface_name ({0}) device type ({1}) for VLAN/PKEY, skipping setup\n".format(iname, ctype))
+                    return
+            cname = iname if not cname else cname
             u = self.uuidbyname.get(cname, None)
             cargs = []
             for arg in cmdargs:
                 cargs.append(arg)
                 cargs.append(cmdargs[arg])
             if u:
-                cargs.append('connection.interface-name')
-                cargs.append(iname)
-                subprocess.check_call(['nmcli', 'c', 'm', u] + cargs)
+                subprocess.check_call(['nmcli', 'c', 'm', u, 'connection.interface-name', iname] + cargs)
                 subprocess.check_call(['nmcli', 'c', 'u', u])
             else:
-                subprocess.check_call(['nmcli', 'c', 'add', 'type', self.devtypes[iname], 'con-name', cname, 'connection.interface-name', iname] + cargs)
+                subprocess.check_call(['nmcli', 'c', 'add', 'type', ctype, 'con-name', cname, 'connection.interface-name', iname] + cargs)
                 self.read_connections()
                 u = self.uuidbyname.get(cname, None)
                 if u:

--- a/confluent_osdeploy/common/profile/scripts/confignet
+++ b/confluent_osdeploy/common/profile/scripts/confignet
@@ -405,7 +405,10 @@ class NetworkManager(object):
         else:
             cname = stgs.get('connection_name', None)
             iname = list(cfg['interfaces'])[0]
-            ctype = self.devtypes[iname]
+            ctype = self.devtypes.get(iname, None)
+            if not ctype:
+                sys.stderr.write("Warning, no device found for interface_name ({0}), skipping setup\n".format(iname))
+                return
             if stgs.get('vlan_id', None):
                 vlan = stgs['vlan_id']
                 if ctype == 'infiniband':

--- a/confluent_osdeploy/common/profile/scripts/confignet
+++ b/confluent_osdeploy/common/profile/scripts/confignet
@@ -416,13 +416,11 @@ class NetworkManager(object):
                     cmdargs['infiniband.parent'] = iname
                     cmdargs['infiniband.p-key'] = vlan
                     iname = '{0}.{1}'.format(iname, vlan[2:])
-                    cname = iname if not cname else cname
                 elif ctype == 'ethernet':
                     ctype = 'vlan'
                     cmdargs['vlan.parent'] = iname
                     cmdargs['vlan.id'] = vlan
                     iname = '{0}.{1}'.format(iname, vlan)
-                    cname = iname if not cname else cname
                 else:
                     sys.stderr.write("Warning, unknown interface_name ({0}) device type ({1}) for VLAN/PKEY, skipping setup\n".format(iname, ctype))
                     return

--- a/confluent_osdeploy/common/profile/scripts/confignet
+++ b/confluent_osdeploy/common/profile/scripts/confignet
@@ -516,6 +516,8 @@ if __name__ == '__main__':
             netname_to_interfaces['default']['interfaces'] -= netname_to_interfaces[netn]['interfaces']
         if not netname_to_interfaces['default']['interfaces']:
             del netname_to_interfaces['default']
+    # Make sure VLAN/PKEY connections are created last
+    netname_to_interfaces = dict(sorted(netname_to_interfaces.items(), key=lambda item: 'vlan_id' in item[1]['settings']))
     rm_tmp_llas(tmpllas)
     if os.path.exists('/usr/sbin/netplan'):
         nm = NetplanManager(dc)

--- a/confluent_server/confluent/config/attributes.py
+++ b/confluent_server/confluent/config/attributes.py
@@ -469,9 +469,13 @@ node = {
     'net.interface_names': {
         'description': 'Interface name or comma delimited list of names to match for this interface. It is generally recommended '
                        'to leave this blank unless needing to set up interfaces that are not on a common subnet with a confluent server, '
-                       'as confluent servers provide autodetection for matching the correct network definition to an interface.'
+                       'as confluent servers provide autodetection for matching the correct network definition to an interface. '
                        'This would be the default name per the deployed OS and can be a comma delimited list to denote members of '
-                       'a team'
+                       'a team or a single interface for VLAN/PKEY connections.'
+    },
+    'net.vlan_id': {
+        'description': 'Ethernet VLAN or InfiniBand PKEY to use for this connection. '
+                       'Specify the parent device using net.interface_names.'
     },
     'net.ipv4_address': {
         'description': 'When configuring static, use this address.  If '

--- a/confluent_server/confluent/netutil.py
+++ b/confluent_server/confluent/netutil.py
@@ -193,6 +193,9 @@ class NetManager(object):
         iname = attribs.get('interface_names', None)
         if iname:
             myattribs['interface_names'] = iname
+        vlanid = attribs.get('vlan_id', None)
+        if vlanid:
+            myattribs['vlan_id'] = vlanid
         teammod = attribs.get('team_mode', None)
         if teammod:
             myattribs['team_mode'] = teammod


### PR DESCRIPTION
Introduce new node attribute net.vlan_id to support VLAN/PKEY configuration using confignet.

Example config with various different options:

```
cstor3: net.ib0-io.connection_name: ibs1.8002
cstor3: net.ib0-io.hostname: cstor3-ib0-io
cstor3: net.ib0-io.interface_names: ibs1
cstor3: net.ib0-io.ipv4_address: 172.24.201.4/20
cstor3: net.ib0-io.vlan_id: 8002
cstor3: net.ib1-io.hostname: cstor3-ib1-io
cstor3: net.ib1-io.interface_names: ibs3
cstor3: net.ib1-io.ipv4_address: 172.24.201.28/20
cstor3: net.ib1-io.vlan_id: 8002
cstor3: net.test.connection_name: myconn
cstor3: net.test.interface_names: ens6f0
cstor3: net.test.ipv4_address: 10.10.10.10/24
cstor3: net.test.vlan_id: 10
```

```
[root@cstor3 ~]# nmcli c s
NAME       UUID                                  TYPE        DEVICE    
ens6f0     d1d69f05-2090-4fcf-98e4-cc22ba4ab37b  ethernet    ens6f0    
ibs1.8002  8669fa60-0189-4cc1-8700-755d0c4b187e  infiniband  ibs1.8002 
ibs3.8002  915cffd1-69cc-483b-8659-cd687880388f  infiniband  ibs3.8002 
myconn     109c59be-9e41-4fc7-bfca-3a820bc45b89  vlan        ens6f0.10 
```

TODOs:

- [ ] Add support for Netplan
- [ ] Add support for Wicked
- [x] Create parent device (`net.interface_name`) if it does not exist
  - This could lead to issues if parent device is some special device like a bond. Maybe require users to define parent device in node attributes?
- [ ] Add more documentation to https://hpc.lenovo.com/users/documentation/?