### PR TITLE
add a loop to find the accessible deployer when the method is not static

### DIFF
--- a/confluent_osdeploy/ubuntu20.04/initramfs/scripts/init-premount/confluent
+++ b/confluent_osdeploy/ubuntu20.04/initramfs/scripts/init-premount/confluent
@@ -56,6 +56,12 @@ if [ -e /dev/disk/by-label/CNFLNT_IDNT ]; then
         echo $NIC > /tmp/autodetectnic
     else
         configure_networking
+        for dsrv in $deploysrvs; do
+            if openssl s_client -connect $dsrv:443 > /dev/null 2>&1; then
+                deploysrvs=$dsrv
+                break
+            fi
+        done
     fi
     MGR=$deploysrvs
     NODENAME=$(grep ^nodename: /tmp/idntmnt/cnflnt.yml | awk '{print $2}')

--- a/confluent_osdeploy/ubuntu22.04/initramfs/scripts/init-premount/confluent
+++ b/confluent_osdeploy/ubuntu22.04/initramfs/scripts/init-premount/confluent
@@ -56,6 +56,12 @@ if [ -e /dev/disk/by-label/CNFLNT_IDNT ]; then
         echo $NIC > /tmp/autodetectnic
     else
         configure_networking
+        for dsrv in $deploysrvs; do
+            if openssl s_client -connect $dsrv:443 > /dev/null 2>&1; then
+                deploysrvs=$dsrv
+                break
+            fi
+        done
     fi
     MGR=$deploysrvs
     NODENAME=$(grep ^nodename: /tmp/idntmnt/cnflnt.yml | awk '{print $2}')


### PR DESCRIPTION
Currently, rocky works when we mount a sign image because it has cyclic logic to find accessible deployer when the method is not static. However, it has been observed that the ubuntu deployment is not working @jjohnson42 