### PR TITLE
Support FQDN first (Fix #167)

### DIFF
--- a/confluent_client/bin/confluent2hosts
+++ b/confluent_client/bin/confluent2hosts
@@ -118,6 +118,7 @@ def main():
     ap.add_argument('-a', '--attrib', help='Pull ip addresses and hostnames from attribute database', action='store_true')
     ap.add_argument('-i', '--ip', help='Expression to generate addresses (e.g. 172.16.1.{n1} or fd2b:246f:8a50::{n1:x})')
     ap.add_argument('-n', '--name', help='Expression for name to add ({node}-compute, etc). If unspecified, "{node} {node}.{dns.domain}" will be used', action='append')
+    ap.add_argument('-f', '--fqdn-first', help='Put the FQDN first in the hosts entries', action='store_true')
     args = ap.parse_args()
     c = client.Command()
     if args.name:
@@ -173,7 +174,13 @@ def main():
                                     break
                             else:
                                 for name in list(names):
-                                    names.append('{0}.{1}'.format(name, mydomain))
+                                    fqdn = '{0}.{1}'.format(name, mydomain)
+                                    if args.fqdn_first:
+                                        # Insert FQDN at the beginning if --fqdn-first flag is set
+                                        names.insert(0, fqdn)
+                                    else:
+                                        # Otherwise, append FQDN at the end (original behavior)
+                                        names.append(fqdn)
                     names = ' '.join(names)
                     merger.add_entry(ipdb[node][currnet], names)
         merger.write_out('/etc/whatnowhosts')

--- a/confluent_client/doc/man/confluent2hosts.ronn
+++ b/confluent_client/doc/man/confluent2hosts.ronn
@@ -13,7 +13,7 @@ noderange.  There are two general approaches.
 
 It can be used ad-hoc, using -i and -n to specify the address and name portions respectively.  This accepts the standard confluent expression syntax, allowing for things like 172.30.1.{n1} or {node}.{dns.domain} or {bmc}.
 
-It can also read from the confluent db, using `-a`.  In this mode, each net.<value>.<attribute> group is pulled together into hosts lines.  ipv4_address and ipv6_address fields are associated with the corresponding hostname attributes.
+It can also read from the confluent db, using `-a`.  In this mode, each net.<value>.<attribute> group is pulled together into hosts lines.  ipv4_address and ipv6_address fields are associated with the corresponding hostname attributes. You can use `-f` to put the FQDN first.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Implements https://github.com/xcat2/confluent/issues/167

Allows to use -a together with -f to get `{ip} {node}.{dns.domain} {node}` format which is needed by some tools for proper name resolution, certificate checks etc.