### PR TITLE
seperate console redirect scripts into oses

### DIFF
--- a/confluent_osdeploy/el9-diskless/profiles/default/scripts/sample/consoleredirect
+++ b/confluent_osdeploy/el9-diskless/profiles/default/scripts/sample/consoleredirect
@@ -1,0 +1,15 @@
+is_rhel=false
+
+if test -f /boot/efi/EFI/redhat/grub.cfg; then
+    grubcfg="/etc/default/grub"
+    is_rhel=true
+else
+    echo "Expected File missing: Check if os redhat"
+    exit
+fi
+
+# Working on Redhat
+if $is_rhel; then
+    sed -i '/^GRUB_TERMINAL/s/serial //' $grubcfg
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+fi

--- a/confluent_osdeploy/suse15/profiles/hpc/scripts/sample/consoleredirect
+++ b/confluent_osdeploy/suse15/profiles/hpc/scripts/sample/consoleredirect
@@ -1,15 +1,11 @@
 is_suse=false
-is_rhel=false
 
-if test -f /boot/efi/EFI/redhat/grub.cfg; then
-    grubcfg="/etc/default/grub"
-    is_rhel=true
-elif test -f /boot/efi/EFI/sle_hpc/grub.cfg; then
+if test -f /boot/efi/EFI/sle_hpc/grub.cfg; then
     grubcfg="/boot/efi/EFI/sle_hpc/grub.cfg"
     grub2-mkconfig -o $grubcfg
     is_suse=true
 else
-    echo "Expected File missing: Check if os sle_hpc or redhat"
+    echo "Expected File missing: Check if os sle_hpc"
     exit
 fi
 
@@ -40,10 +36,4 @@ if $is_suse; then
         sed -i "${line_num},^,#," $grubcfg
     done
     sed -i 's,^terminal,#terminal,' $grubcfg
-fi
-
-# Working on Redhat
-if $is_rhel; then
-    sed -i '/^GRUB_TERMINAL/s/serial //' $grubcfg
-    grub2-mkconfig -o /boot/grub2/grub.cfg
 fi


### PR DESCRIPTION
This is to ensure that we place scripts in oses that we have explicitly tested 