### PR TITLE
Show valid values from attributes.py in man pages

### DIFF
--- a/confluent_client/addattribs.py
+++ b/confluent_client/addattribs.py
@@ -14,11 +14,16 @@ import shutil
 
 shutil.copyfile('doc/man/nodeattrib.ronn.tmpl', 'doc/man/nodeattrib.ronn')
 shutil.copyfile('doc/man/nodegroupattrib.ronn.tmpl', 'doc/man/nodegroupattrib.ronn')
-with open('doc/man/nodeattrib.ronn', 'a') as outf:
-    for field in sorted(attr.node):
-        outf.write('\n* `{0}`:\n  {1}\n'.format(field, attr.node[field]['description']))
-with open('doc/man/nodegroupattrib.ronn', 'a') as outf:
-    for field in sorted(attr.node):
-        outf.write('\n* `{0}`:\n  {1}\n'.format(field, attr.node[field]['description']))
 
+def append_attributes(filename):
+    with open(filename, 'a') as outf:
+        for field in sorted(attr.node):
+            outf.write('\n* `{0}`:\n  {1}\n'.format(field, attr.node[field]['description']))
+            # Optionally write valid values if they exist
+            for key, values in attr.node[field].items():
+                if key.startswith('valid'):
+                    values_formatted = ', '.join("'{0}'".format(v) for v in values)
+                    outf.write(f'\n    Valid values: {values_formatted}\n')
 
+append_attributes('doc/man/nodeattrib.ronn')
+append_attributes('doc/man/nodegroupattrib.ronn')

--- a/confluent_server/confluent/config/attributes.py
+++ b/confluent_server/confluent/config/attributes.py
@@ -265,8 +265,7 @@ node = {
     },
     'discovery.policy': {
         'description':  'Policy to use for auto-configuration of discovered '
-                        'and identified nodes. Valid values are "manual", '
-                        '"permissive", or "open". "manual" means nodes are '
+                        'and identified nodes. "manual" means nodes are '
                         'detected, but not autoconfigured until a user '
                         'approves. "permissive" indicates to allow discovery, '
                         'so long as the node has no existing public key. '
@@ -361,9 +360,8 @@ node = {
 #                        'to suppress serial console configuration')
 #    },
     'console.logging': {
-        'description': ('Indicate logging level to apply to console.  Valid '
-                        'values are currently "full", "interactive", "memory", and '
-                        '"none". Defaults to "full".'),
+        'description': ('Indicate logging level to apply to console. '
+                        'Defaults to "full".'),
         'validvalues': ('full', 'memory', 'interactive', 'none'),
     },
     'console.method': {


### PR DESCRIPTION
This adds all valid values of `confluent_server/confluent/config/attributes.py` to man pages.

_Note: This is implemented in upcoming confluent-docs PR already: https://github.com/Obihoernchen/confluent-docs/commit/107e011a6f5c391c5d3ec8cc367c315dc0b3b4f6 https://github.com/Obihoernchen/confluent-docs/commit/47f8eed050bf6a49ede02d440b03014d9fbf1bce_

We might want to use the same name for valid values in `confluent_server/confluent/config/attributes.py`.
Currently there is:

- validvalues
- validlist
- validlistkeys
- valid_values

Furthermore, it might be nice to define the default value in `confluent_server/confluent/config/attributes.py` as well to show it in man pages.

I'll open issues for this.

