### PR TITLE
Configure the logdirectory from the configuration file

### DIFF
--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -94,6 +94,7 @@ def _daemonize():
 
 def _redirectoutput():
     os.umask(63)
+    configmanager.set_global('logdirectory', _get_logdirectory())
     sys.stdout = log.Logger('stdout', buffered=False)
     sys.stderr = log.Logger('stderr', buffered=False)
 
@@ -340,3 +341,6 @@ def _get_connector_config(session):
     host = conf.get_option(session, 'bindhost')
     port = conf.get_int_option(session, 'bindport')
     return (host, port)
+
+def _get_logdirectory():
+    return conf.get_option('globals', 'logdirectory')


### PR DESCRIPTION
- Set the log directory using the configuration manager
- Add _get_logdirectory function to retrieve the log directory path
- Update _redirectoutput to use the new log directory setting