### PR TITLE
Add documentation for custom nodeattribs

### DIFF
--- a/confluent_client/doc/man/nodeattrib.ronn.tmpl
+++ b/confluent_client/doc/man/nodeattrib.ronn.tmpl
@@ -24,6 +24,8 @@ For a full list of attributes, run `nodeattrib <node> all` against a node.
 If `-c` is specified, this will set the nodeattribute to a null value.
 This is different from setting the value to an empty string.
 
+Arbitrary custom attributes can also be created with the `custom.` prefix.
+
 Attributes may be specified by wildcard, for example `net.*switch` will report
 all attributes that begin with `net.` and end with `switch`.
 


### PR DESCRIPTION
An awesome feature which is not known by most people.
Let's add this to the man page.