### PR TITLE
Fix EL9 aarch support

### DIFF
--- a/confluent_osdeploy/confluent_osdeploy-aarch64.spec.tmpl
+++ b/confluent_osdeploy/confluent_osdeploy-aarch64.spec.tmpl
@@ -26,7 +26,7 @@ mkdir -p opt/confluent/bin
 mkdir -p stateless-bin
 cp -a el8bin/* .
 ln -s el8 el9
-ln -s el8 el10
+cp -a el8 el10
 cp -a debian debian13
 mkdir -p debian13/initramfs/usr
 mv debian13/initramfs/lib debian13/initramfs/usr/


### PR DESCRIPTION
This PR allows builds on EL9 aarch systems. Tested using the OpenHPC 3.x Markdown install scripts on Rocky-9.7 using qemu on a M3 Mac.

Fix el8/el9 hook paths corrupted by symlinked el10 in aarch64 spec

In confluent_osdeploy-aarch64.spec.tmpl, el10 was created as a symlink to el8, so the subsequent `mv el10/initramfs/usr el10/initramfs/var` inadvertently renamed el8's usr directory, leaving el8 and el9 (also symlinked to el8) with hooks at var/lib/dracut/hooks/ instead of usr/lib/dracut/hooks/. Rocky 9 dracut never found the hooks and dropped to the emergency shell on all aarch64 nodes.

Use `cp -a el8 el10` as the x86_64 spec already does, so the rename only affects the el10 copy.

