### PR TITLE
Fix software RAID creation with newer mdadm versions

### DIFF
--- a/misc/swraid
+++ b/misc/swraid
@@ -7,6 +7,7 @@ NUMDEVS=$(for dev in $DEVICES; do
    echo wipefs -a -f $dev
 done|wc -l)
 for dev in $DEVICES; do
+   mdadm --zero-superblock $dev
    wipefs -a -f $dev
 done
 # must use older metadata format to leave disks looking normal for uefi
@@ -15,9 +16,15 @@ mdadm -C /dev/md/raid $DEVICES -n $NUMDEVS -e 1.0 -l $RAIDLEVEL -b internal
 mdadm -S -s
 mdadm --assemble --scan
 )
-while [ ! -e /dev/md/raid ]; do
+while :; do
+    # newer mdraid verions might have <hostname>:<raidname>
+    TARGET_RAID=$(ls /dev/md/raid /dev/md/*:raid 2>/dev/null | head -n 1)
+
+    [ -n "$TARGET_RAID" ] && break
+
     echo 'Waiting on array to be linked...'
     sleep 0.5
 done
-readlink /dev/md/raid|sed -e 's/.*\///' > /tmp/installdisk
 
+# Extract the underlying block device name (e.g., md127) using the captured path
+readlink "$TARGET_RAID" | sed -e 's/.*\///' > /tmp/installdisk

--- a/misc/swraid
+++ b/misc/swraid
@@ -10,7 +10,7 @@ for dev in $DEVICES; do
    wipefs -a -f $dev
 done
 # must use older metadata format to leave disks looking normal for uefi
-mdadm -C /dev/md/raid $DEVICES -n $NUMDEVS -e 1.0 -l $RAIDLEVEL
+mdadm -C /dev/md/raid $DEVICES -n $NUMDEVS -e 1.0 -l $RAIDLEVEL -b internal
 # shut and restart array to prime things for anaconda
 mdadm -S -s
 mdadm --assemble --scan


### PR DESCRIPTION
Three changes:

1. Recent mdadm versions introduced an interactive prompt when creating RAID arrays without an explicit bitmap configuration:
  `To optimize recovery speed, it is recommended to enable write-intent bitmap, do you want to enable it now? [y/N]?`
This behavior was introduced by upstream change:
https://github.com/md-raid-utilities/mdadm/commit/e97c4e18c847803016aa60066cb6e57c528d83a6
In non-interactive environments such as Anaconda, this prompt blocks installation and causes RAID creation to hang.
Fix this by explicitly enabling the internal bitmap when creating RAID arrays.

2. Handle hostname-prefixed md device names
Newer mdadm versions may load arrays under names like
`/dev/md/<hostname>:raid` after reboot instead of `/dev/md/raid`. Detect both
naming schemes when waiting for the array device and use the resolved
path consistently when determining the underlying md device name.
    
3. Also clear existing md superblocks before wiping signatures to avoid
stale RAID metadata interfering with array creation or assembly.
