### PR TITLE
Include xen-front drivers in initramfs

### DIFF
--- a/genesis/97genesis/installkernel
+++ b/genesis/97genesis/installkernel
@@ -5,6 +5,7 @@ if grep Ubuntu /etc/os-release > /dev/null; then # must include specific drivers
     instmods nls_iso8859-1
 fi
 instmods virtio_net
+instmods xen-netfront xen-blkfront xen-pcifront
 instmods e1000 e1000e igb sfc mlx5_ib mlx5_core mlx4_en cxgb3 cxgb4 tg3 bnx2 bnx2x bna ixgb ixgbe qlge mptsas mpt2sas mpt3sas megaraid_sas ahci xhci-hcd sd_mod pmcraid be2net vfat ext3 ext4 usb_storage scsi_wait_scan ipmi_si ipmi_devintf qlcnic xfs
 instmods nvme
 instmods cdc_ether r8152

--- a/imgutil/el10/dracut/installkernel
+++ b/imgutil/el10/dracut/installkernel
@@ -6,6 +6,7 @@ instmods cdc_ether r8152
 instmods r8169
 instmods vmxnet3 virtio_net
 instmods virtio_scsi vmw_pvscsi
+instmods xen-netfront xen-blkfront xen-pcifront
 instmods mptctl
 instmods mlx4_ib mlx5_ub ib_umad ib_ipoib
 instmods ice i40e hfi1 bnxt_en qed qede

--- a/imgutil/el7/dracut/installkernel
+++ b/imgutil/el7/dracut/installkernel
@@ -3,6 +3,7 @@ instmods nfsv3 nfs_acl nfsv4 dns_resolver lockd fscache sunrpc
 instmods e1000 e1000e igb sfc mlx5_ib mlx5_core mlx4_en cxgb3 cxgb4 tg3 bnx2 bnx2x bna ixgb ixgbe qlge mptsas mpt2sas mpt3sas megaraid_sas ahci xhci-hcd sd_mod pmcraid be2net vfat ext3 ext4 usb_storage scsi_wait_scan ipmi_si ipmi_devintf qlcnic xfs
 instmods nvme
 instmods cdc_ether
+instmods xen-netfront xen-blkfront xen-pcifront
 instmods mptctl
 instmods mlx4_ib mlx5_ub ib_umad ib_ipoib
 instmods ice i40e hfi1 bnxt_en qed qede

--- a/imgutil/el8/dracut/installkernel
+++ b/imgutil/el8/dracut/installkernel
@@ -6,6 +6,7 @@ instmods cdc_ether r8152
 instmods r8169
 instmods vmxnet3 virtio_net
 instmods virtio_scsi vmw_pvscsi
+instmods xen-netfront xen-blkfront xen-pcifront
 instmods mptctl
 instmods mlx4_ib mlx5_ub ib_umad ib_ipoib
 instmods ice i40e hfi1 bnxt_en qed qede

--- a/imgutil/el9/dracut/installkernel
+++ b/imgutil/el9/dracut/installkernel
@@ -6,6 +6,7 @@ instmods cdc_ether r8152
 instmods r8169
 instmods vmxnet3 virtio_net
 instmods virtio_scsi vmw_pvscsi
+instmods xen-netfront xen-blkfront xen-pcifront
 instmods mptctl
 instmods mlx4_ib mlx5_ub ib_umad ib_ipoib
 instmods ice i40e hfi1 bnxt_en qed qede

--- a/imgutil/suse15/dracut/installkernel
+++ b/imgutil/suse15/dracut/installkernel
@@ -3,6 +3,7 @@ instmods nfsv3 nfs_acl nfsv4 dns_resolver lockd fscache sunrpc
 instmods e1000 e1000e igb sfc mlx5_ib mlx5_core mlx4_en cxgb3 cxgb4 tg3 bnx2 bnx2x bna ixgb ixgbe qlge mptsas mpt2sas mpt3sas megaraid_sas ahci xhci-hcd sd_mod pmcraid be2net vfat ext3 ext4 usb_storage scsi_wait_scan ipmi_si ipmi_devintf qlcnic xfs
 instmods nvme
 instmods cdc_ether r8152
+instmods xen-netfront xen-blkfront xen-pcifront
 instmods mptctl
 instmods mlx4_ib mlx5_ub ib_umad ib_ipoib
 instmods ice i40e hfi1 bnxt_en qed qede

--- a/imgutil/ubuntu/initramfs-tools/hooks/confluent
+++ b/imgutil/ubuntu/initramfs-tools/hooks/confluent
@@ -49,3 +49,4 @@ manual_add_modules ice i40e hfi1 bnxt_en qed qede dm-mod dm-log raid0 raid1
 manual_add_modules raid10 raid456 dm-raid dm-thin-pool dm-crypt dm-snapshot
 manual_add_modules linear dm-era fuse overlay squashfs loop zram
 manual_add_modules vmxnet3 r8169
+manual_add_modules xen-netfront xen-blkfront xen-pcifront


### PR DESCRIPTION
This PR restores the availability of stateless nodes when booting within the Xen Hypervisor.

Without this changes, the system fails to boot, just like the image:

<img width="1042" height="142" alt="telegram-cloud-photo-size-1-4938606422514142243-y" src="https://github.com/user-attachments/assets/9a3bafc4-b7c1-42e9-b7f0-3b355df1aa69" />
