### PR TITLE
confignet: Fix interface type detection for IB VFs

### DIFF
--- a/confluent_osdeploy/common/profile/scripts/confignet
+++ b/confluent_osdeploy/common/profile/scripts/confignet
@@ -80,14 +80,18 @@ def await_tentative():
         time.sleep(1)
 
 def map_idx_to_name():
-    map = {}
+    map_dict = {}
     devtype = {}
     prevdev = None
+
     for line in subprocess.check_output(['ip', 'l']).decode('utf8').splitlines():
-        if line.startswith(' ') and 'link/' in line:
-            typ = line.split()[0].split('/')[1]
-            devtype[prevdev] = typ if typ != 'ether' else 'ethernet'
         if line.startswith(' '):
+            if 'link/' in line and prevdev and prevdev not in devtype:
+                for word in line.split():
+                    if word.startswith('link/'):
+                        typ = word.split('/')[1]
+                        devtype[prevdev] = typ if typ != 'ether' else 'ethernet'
+                        break # Stop detection after the first type hit
             continue
         idx, iface, rst = line.split(':', 2)
         prevdev = iface.strip()
@@ -99,9 +103,8 @@ def map_idx_to_name():
             pass
         idx = int(idx)
         iface = iface.strip()
-        map[idx] = iface
-    return map, devtype
-
+        map_dict[idx] = iface
+    return map_dict, devtype
 
 def get_interface_name(iname, settings):
     explicitname = settings.get('interface_names', None)


### PR DESCRIPTION
IB VFs have the following "ip l" output:

```
4: ibp129s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 2044 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/infiniband 00:00:00:8d:fe:80:00:00:00:00:00:00:60:5e:65:03:00:2c:43:c8 brd 00:ff:ff:ff:ff:12:40:1b:ff:ff:00:00:00:00:00:00:ff:ff:ff:ff
    vf 0     link/infiniband 00:00:00:8d:fe:80:00:00:00:00:00:00:60:5e:65:03:00:2c:43:c8 brd 00:ff:ff:ff:ff:12:40:1b:ff:ff:00:00:00:00:00:00:ff:ff:ff:ff, spoof checking off, NODE_GUID 00:00:00:00:00:00:00:00, PORT_GUID 00:00:00:00:00:00:00:00, link-state enable, trust off, query_rss off
5: eno1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000
    link/ether 30:56:0f:17:c0:b4 brd ff:ff:ff:ff:ff:ff
    altname enp196s0
    altname enx30560f17c0b4
```

This breaks the detection script because index 0 of the "vf 0 ..." line is not link/<type> anymore. This commit improves the detection logic to fix this.

Fixes:
```
# nodeapply ds2 -P confignet
ds2: 
ds2: ---------------------------------------------------------------------------
ds2: Running 'confignet' from https://10.248.10.1/confluent-public/os/alma-10.1-x86_64-default/scripts/
ds2: Executing in /opt/confluent/tmpexec/confluentscripts.7IBMIaMyy
ds2: ○ firewalld.service - firewalld - dynamic firewall daemon
ds2: Traceback (most recent call last):
ds2:      Loaded: loaded (/usr/lib/systemd/system/firewalld.service; disabled; preset: enabled)
ds2:      Active: inactive (dead)
ds2:        Docs: man:firewalld(1)
ds2: 'confignet' exited with code 1
ds2:   File "/opt/confluent/tmpexec/confluentscripts.7IBMIaMyy/./confignet", line 472, in <module>
ds2:     idxmap, devtypes = map_idx_to_name()
ds2:                        ^^^^^^^^^^^^^^^^^
ds2:   File "/opt/confluent/tmpexec/confluentscripts.7IBMIaMyy/./confignet", line 88, in map_idx_to_name
ds2:     typ = line.split()[0].split('/')[1]
ds2:           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
ds2: IndexError: list index out of range
```