### PR TITLE
Add missing validvalues to attributes.py

### DIFF
--- a/confluent_server/confluent/config/attributes.py
+++ b/confluent_server/confluent/config/attributes.py
@@ -417,7 +417,11 @@ node = {
     'hardwaremanagement.method': {
         'description': 'The method used to perform operations such as power '
                        'control, get sensor data, get inventory, and so on. '
-                       'ipmi is used if not specified.'
+                       'ipmi is used if not specified.',
+        'validvalues': ('affluent', 'cnos', 'cooltera', 'deltapdu',
+                        'eatonpdu', 'enclosure', 'enlogic', 'enos', 'geist',
+                        'ipmi', 'null', 'nxos', 'pdu', 'proxmox', 'raritan',
+                        'redfish', 'srlinux', 'vcenter'),
     },
     'hardwaremanagement.port': {
         'description': 'The port the BMC should be configured to connect to '

--- a/confluent_server/confluent/config/attributes.py
+++ b/confluent_server/confluent/config/attributes.py
@@ -610,7 +610,7 @@ node = {
     },
     'snmp.privacyprotocol': {
         'description': 'The privacy protocol to use for SNMPv3',
-        'valid_values': ('aes', 'des'),
+        'validvalues': ('aes', 'des'),
     },
 #    'secret.snmplocalizedkey': {
 #        'description': ("SNMPv3 key localized to this node's SNMP Engine id"
@@ -657,7 +657,7 @@ node = {
                         'Note that if the trusted CA verifies the certificate,'
                         ' that is accepted ignoring this policy.  Default '
                         'policy is "automatic"'),
-        'valid_values': ('automatic', 'manual'),
+        'validvalues': ('automatic', 'manual'),
     },
     'pubkeys.tls_hardwaremanager': {
         'description':  ('Fingerprint of the TLS certificate recognized as'


### PR DESCRIPTION
This PR adds some missing `validvalues` to `confluent_server/confluent/config/attributes.py`.

- `validvalues` for `hardwaremanagement.method` were missing
- `validvalues` for `snmp.privacyprotocol` and `pubkeys.addpolicy` had a typo (`valid_values`) and were not verified because of this. Note: This can break existing scripts if invalid values are used.

Fixes: https://github.com/xcat2/confluent/issues/186 and https://github.com/xcat2/confluent/issues/189