### PR TITLE
Fix pubkeys.addpolicy documentation to match implementation

### DIFF
--- a/confluent_server/confluent/config/attributes.py
+++ b/confluent_server/confluent/config/attributes.py
@@ -655,13 +655,19 @@ node = {
     },
     'pubkeys.addpolicy': {
         'description': ('Policy to use when encountering unknown public '
-                        'keys.  Choices are "automatic" to accept and '
-                        'store new key if no key known and "manual" '
-                        'to always reject a new key, even if no key known'
-                        'Note that if the trusted CA verifies the certificate,'
-                        ' that is accepted ignoring this policy.  Default '
-                        'policy is "automatic"'),
-        'validvalues': ('automatic', 'manual'),
+                        'keys.  If unset (default), behaves as "tofu" '
+                        '(trust-on-first-use): accept and store a new key '
+                        'if no key is currently known.  "manual" always '
+                        'rejects a new key, even if no key is known, '
+                        'requiring it to be pinned manually.  "ca" requires '
+                        'the trusted CA to validate the certificate before '
+                        'pinning a new or changed key, but a previously '
+                        'pinned key that still matches is trusted without '
+                        're-checking the CA.  "ca-only" is stricter: it '
+                        'requires the trusted CA to validate the '
+                        'certificate on every check, even when a '
+                        'previously pinned key would otherwise match.'),
+        'validvalues': ('tofu', 'manual', 'ca', 'ca-only'),
     },
     'pubkeys.tls_hardwaremanager': {
         'description':  ('Fingerprint of the TLS certificate recognized as'


### PR DESCRIPTION
validvalues listed 'automatic'/'manual', but that was outdated. Commit 454e1b82675a9043ba367e0086680b3f8ece677f and cc70dcfa2b491e9bc6966c69625180f20e358530 implemented unset/'tofu' (trust-on-first-use, the default), 'manual', 'ca-only', and an implicit 'ca' (any value that isn't otherwise handled falls through to the standard CA-verification path, keying an already pinned match without a full CA reverify).
The validvalues fix in ecaa75d96710bb1dce95bc08f4ebbe5ee047dee6 rejected these new values. Add new valid values with proper documentation.