### PR TITLE
Fix typos and small bugs found during a documentation/UI text review

### DIFF
--- a/confluent_client/bin/confetty
+++ b/confluent_client/bin/confetty
@@ -108,8 +108,8 @@ class BailOut(Exception):
 def print_help():
     print("confetty provides a filesystem like interface to confluent.  "
           "Navigation is done using the same commands as would be used in a "
-          "filesystem.  Tab completion is supported to aid in navigation,"
-          "as is up arrow to recall previous commands and control-r to search"
+          "filesystem.  Tab completion is supported to aid in navigation, "
+          "as is up arrow to recall previous commands and control-r to search "
           "previous command history, similar to using bash\n\n"
           "The supported commands are:\n"
           "cd [location] - Set the current command context, similar to a "

--- a/confluent_client/bin/confluent2hosts
+++ b/confluent_client/bin/confluent2hosts
@@ -183,7 +183,6 @@ def main():
                                         names.append(fqdn)
                     names = ' '.join(names)
                     merger.add_entry(ipdb[node][currnet], names)
-        merger.write_out('/etc/whatnowhosts')
     else:
         namesbynode = {}
         ipbynode = {}

--- a/confluent_client/bin/nodeattrib
+++ b/confluent_client/bin/nodeattrib
@@ -45,7 +45,7 @@ async def main():
                 \n       %prog noderange attribute1=value1 attribute2=value,...
                 \n ''')
     argparser.add_option('-b', '--blame', action='store_true',
-                        help='Show information about how attributes inherited')
+                        help='Show information about how attributes are inherited')
     argparser.add_option('-e', '--environment', action='store_true',
                         help='Set attributes, but from environment variable of '
                             'same name')

--- a/confluent_client/bin/nodebmcpassword
+++ b/confluent_client/bin/nodebmcpassword
@@ -40,7 +40,7 @@ argparser.add_option('-m', '--maxnodes', type='int',
 argparser.add_option('-p', '--prompt', action='store_true',
                      help='Prompt for password values interactively')
 argparser.add_option('-e', '--environment', action='store_true',
-                     help='Set passwod, but from environment variable of '
+                     help='Set password, but from environment variable of '
                           'same name')
 
 

--- a/confluent_client/bin/nodeconsole
+++ b/confluent_client/bin/nodeconsole
@@ -106,7 +106,7 @@ argparser.add_option('-w','--windowed', action='store_true', default=False,
                           'title set for each node, set NODECONSOLE_WINDOWED_COMMAND'
                           ' to "wt.exe wsl.exe -d AlmaLinux-8 '
                           '--shell-type login".  If the NODECONSOLE_WINDOWED_COMMAND '
-                          'environment variable isn\'t set, xterm will be used by'
+                          'environment variable isn\'t set, xterm will be used by '
                           'default.')
 
 (options, args) = argparser.parse_args()

--- a/confluent_client/bin/nodedeploy
+++ b/confluent_client/bin/nodedeploy
@@ -80,7 +80,7 @@ def main(args):
     ap.add_argument('-n', '--network', help='Initiate deployment over PXE/HTTP', action='store_true')
     ap.add_argument('-b', '--bootmethod', help='Specify network boot method (e.g., network, http)', default='network')
     ap.add_argument('-p', '--prepareonly', help='Prepare only, skip any interaction with a BMC associated with this deployment action', action='store_true')
-    ap.add_argument('-m', '--maxnodes', help='Specifiy a maximum nodes to be deployed')
+    ap.add_argument('-m', '--maxnodes', help='Specify a maximum nodes to be deployed')
     ap.add_argument('-r', '--redeploy', help='Redeploy nodes with the current or pending profile', action='store_true')
     ap.add_argument('noderange', help='Set of nodes to deploy')
     ap.add_argument('profile', nargs='?', help='Profile name to deploy')

--- a/confluent_client/bin/nodegroupattrib
+++ b/confluent_client/bin/nodegroupattrib
@@ -42,7 +42,7 @@ argparser = optparse.OptionParser(
              \n       %prog [options] nodegroup nodes=value1,value2
              \n ''')
 argparser.add_option('-b', '--blame', action='store_true',
-                     help='Show information about how attributes inherited')
+                     help='Show information about how attributes are inherited')
 argparser.add_option('-e', '--environment', action='store_true',
                      help='Set attributes, but from environment variable of '
                           'same name')

--- a/confluent_client/bin/nodel2traceroute
+++ b/confluent_client/bin/nodel2traceroute
@@ -162,7 +162,7 @@ for end_node in end_nodeslist:
     if end_node:
         end_switches = host_to_switch(end_node, eface)
         if not end_switches:
-            print('Error: net.{0}.switch attribute is not valid')
+            print('Error: net.{0}.switch attribute is not valid'.format(eface))
             continue
         path = path_between_nodes(start_switches, end_switches)
         print(f'{start_node} to {end_node}: {path}')

--- a/confluent_client/bin/nodelist
+++ b/confluent_client/bin/nodelist
@@ -41,7 +41,7 @@ async def main():
     usage="Usage: %prog noderange\n"
           "   or: %prog [options] noderange <nodeattribute>...")
     argparser.add_option('-b', '--blame', action='store_true',
-                     help='Show information about how attributes inherited')
+                     help='Show information about how attributes are inherited')
     argparser.add_option('-d', '--delim', metavar="STRING", default = "\n",
                      help='Delimiter separating the values')
     (options, args) = argparser.parse_args()

--- a/confluent_client/doc/man/confetty.ronn
+++ b/confluent_client/doc/man/confetty.ronn
@@ -42,7 +42,7 @@ commands.
 * `show` **ELEMENT**, `cat` **ELEMENT**:
   Display the result of reading a specific element (by full or relative path)
 * `unset` **ELEMENT** **ATTRIBUTE**
-  For an element with attributes, request to clear the value of the attribue
+  For an element with attributes, request to clear the value of the attribute
 * `set` **ELEMENT** **ATTRIBUTE**=**VALUE**
   Set the specified attribute to the given value
 * `start` **ELEMENT**

--- a/confluent_client/doc/man/confluentdbutil.ronn
+++ b/confluent_client/doc/man/confluentdbutil.ronn
@@ -10,7 +10,7 @@ confluentdbutil(8) -- Backup or restore confluent database
 **confluentdbutil** is a utility to export/import the confluent attributes
 to/from json files.  The path is a directory that holds the json version.
 In order to perform restore, the confluent service must not be running.  It
-is required to indicate how to treat the usernames/passwords are treated in
+is required to indicate how the usernames/passwords are treated in
 the json files (password protected, removed from the files, or unprotected).
 
 ## OPTIONS
@@ -24,7 +24,7 @@ the json files (password protected, removed from the files, or unprotected).
   
 * `-r`, `--redact`:
   Indicates to replace usernames and passwords with a dummy string rather
-  than included.
+  than including them.
   
 * `-u`, `--unprotected`:
   The keys.json file will include the encryption keys without any protection.
@@ -35,10 +35,10 @@ the json files (password protected, removed from the files, or unprotected).
   suitable for an automated incremental backup, where an
   earlier password protected dump has a protected
   keys.json file, and only the protected data is needed.
-  keys do not change and as such they do not require
+  Keys do not change and as such they do not require
   incremental backup.
-  
-* `-y`, `--yaml
+
+* `-y`, `--yaml`:
   Use YAML instead of JSON as file format
   
   * `-h`, `--help`:

--- a/confluent_client/doc/man/nodeapply.ronn
+++ b/confluent_client/doc/man/nodeapply.ronn
@@ -9,7 +9,7 @@ nodeapply(8) -- Execute command on many nodes in a noderange through ssh
 
 Provides shortcut access to a number of common operations against deployed
 nodes.  These operations include refreshing ssh certificates and configuration,
-rerunning syncflies, and executing specified postscripts.
+rerunning syncfiles, and executing specified postscripts.
 
 ## OPTIONS
   

--- a/confluent_client/doc/man/nodeattrib.ronn.tmpl
+++ b/confluent_client/doc/man/nodeattrib.ronn.tmpl
@@ -42,7 +42,7 @@ For the `groups` attribute, it is possible to add a group by doing
 `groups,=<newgroup>` and to remove by doing `groups^=<oldgroup>`
 
 Note that `nodeattrib <group>` will likely not provide the expected behavior.
-See nodegroupattrib(8) command on how to manage attributes on a group level.  Running
+See the nodegroupattrib(8) command for how to manage attributes on a group level.  Running
 nodeattrib on a group will simply set node-specific attributes on each individual
 member of the group.
 
@@ -68,8 +68,8 @@ to a blank value will allow masking a group defined attribute with an empty valu
   or environment variables.
 
 * `-s`, `--set`:
-  Set attributes using a batch file rather than the command line. The attributes in the batch file 
-  can be specified as one line of key=value pairs simmilar to command line or each attribute can
+  Set attributes using a batch file rather than the command line. The attributes in the batch file
+  can be specified as one line of key=value pairs similar to command line or each attribute can
   be in its own line. Lines that start with # sign will be read as a comment. See EXAMPLES for batch
   file syntax.   
  

--- a/confluent_client/doc/man/nodeattribexpressions.ronn
+++ b/confluent_client/doc/man/nodeattribexpressions.ronn
@@ -44,7 +44,7 @@ It is sometimes the case that the number must be formatted a different way,
 either specifying 0 padding or converting to hexadecimal. This can be done by a
 number of operators at the end to indicate formatting changes.
 
-`{n1:02x} - Zero pad to two decimal places, and convert to hexadecimal, as mightbe used for generating MAC addresses`  
+`{n1:02x} - Zero pad to two decimal places, and convert to hexadecimal, as might be used for generating MAC addresses`
 `{n1:x} - Hexadecimal without padding, as may be used in a generated IPv6 address`  
 `{n1:X} - Uppercase hexadecimal`  
 `{n1:02d} - Zero pad a normal numeric representation of the number.`  

--- a/confluent_client/doc/man/nodebmcpassword.ronn
+++ b/confluent_client/doc/man/nodebmcpassword.ronn
@@ -20,9 +20,9 @@ nodebmcpassword(8) -- Change management controller password for a specified user
 
 ## EXAMPLES:
 
-* Reset the management controller for nodes n1 through n4:
-  `# nodebmcreset n1-n4`  
-  `n1: Password Change Successful`  
-  `n2: Password Change Successful`  
-  `n3: Password Change Successful`  
-  `n4: Password Change Successful`  
+* Change the management controller password for user USERID on nodes n1 through n4:
+  `# nodebmcpassword n1-n4 USERID newp4ssw0rd`
+  `n1: Password Change Successful`
+  `n2: Password Change Successful`
+  `n3: Password Change Successful`
+  `n4: Password Change Successful`

--- a/confluent_client/doc/man/nodeconfig.ronn
+++ b/confluent_client/doc/man/nodeconfig.ronn
@@ -68,7 +68,7 @@ actually be in effect until a reboot.
     `s4: bmc.ipv4_method: DHCP`  
     `s4: bmc.ipv4_gateway: 172.30.0.6`  
 
-* Changing nodes `s3` and `s4` to have the ip addressess 10.1.2.3 and 10.1.2.4 with a 16 bit subnet mask:
+* Changing nodes `s3` and `s4` to have the IP addresses 10.1.2.3 and 10.1.2.4 with a 16 bit subnet mask:
     `# nodeconfig s3,s4 bmc.ipv4_address=10.1.2.{n1}/16`  
 
 ## SEE ALSO

--- a/confluent_client/doc/man/nodeconsole.ronn
+++ b/confluent_client/doc/man/nodeconsole.ronn
@@ -37,7 +37,7 @@ console process which will result in the console window closing.
   manager at this time.
 
   * `-T`, `--Timestamp`:
- Dump the log with Timpstamps on the current, local log in /var/log/confluent/consoles.
+ Dump the log with Timestamps on the current, local log in /var/log/confluent/consoles.
   If in collective mode, this only makes sense to use on the current collective
   manager at this time.
 
@@ -65,9 +65,9 @@ console process which will result in the console window closing.
   environment, to open a set of consoles for a range of
   nodes in separate Windows Terminal windows, with the
   title set for each node, set **NODECONSOLE_WINDOWED_COMMAND**
-  to `wt.exe wsl.exe -d AlmaLinux-8 --shell-type login.  If the
+  to `wt.exe wsl.exe -d AlmaLinux-8 --shell-type login`.  If the
   NODECONSOLE_WINDOWED_COMMAND environment variable isn't set,
-  xterm will be used bydefault.
+  xterm will be used by default.
 
 ## ESCAPE SEQUENCE COMMANDS
 
@@ -102,7 +102,7 @@ keystroke will be interpreted as a command.  The following commands are availabl
   Request immediate boot to network
 * `r`:
   [send Resize]
-  This queries the current terminal and sends stty commands to advertise the user termineal
+  This queries the current terminal and sends stty commands to advertise the user terminal
   size to the remote console
 * `?`:
   Get a list of supported commands
@@ -112,10 +112,10 @@ keystroke will be interpreted as a command.  The following commands are availabl
 
 ## PASSTHROUGH OPTIONS
 
-While opening a windowed console with xterm or any other console of choice. The 
-nodeconsole command gives capality to specify passthrough options targeted at 
-the console. All options after the -- will be parsed the console program. For 
-example, opening a windowed console using xterm with a black background. 
-`nodeconconsole -w n1 -- -bg black`  
+While opening a windowed console with xterm or any other console of choice. The
+nodeconsole command gives capability to specify passthrough options targeted at
+the console. All options after the -- will be passed to the console program. For
+example, opening a windowed console using xterm with a black background.
+`nodeconsole -w n1 -- -bg black`
 
 

--- a/confluent_client/doc/man/nodedefine.ronn
+++ b/confluent_client/doc/man/nodedefine.ronn
@@ -3,7 +3,7 @@ nodedefine(8) -- Define new confluent nodes
 
 ## SYNOPSIS
 
-`nodedefine <noderange> [nodeattribute1=value1> <nodeattribute2=value2> ...]`  
+`nodedefine <noderange> [<nodeattribute1=value1> <nodeattribute2=value2> ...]`
 
 ## DESCRIPTION
 
@@ -26,4 +26,4 @@ that `nodeattrib(8)` will error if a node does not exist.
 
 ## SEE ALSO
 
-noderange(5), nodeattribexpressions(8)
+noderange(5), nodeattribexpressions(5)

--- a/confluent_client/doc/man/nodedeploy.ronn
+++ b/confluent_client/doc/man/nodedeploy.ronn
@@ -27,14 +27,14 @@ deployment status.
   Prepare the network services for deployment, but do not interact with BMCs. This is intended for scenarios where
   the boot device control and server restart will be handled outside of confluent.
   
-* `-m MAXNODES`, `--maxnodes=MAXNODES`: 
-  Specifiy a maximum nodes to be deployed.
+* `-m MAXNODES`, `--maxnodes=MAXNODES`:
+  Specify a maximum number of nodes to be deployed.
   
 * `-h`, `--help`:
   Show help message and exit  
 
 ## EXAMPLES
-* Begin the instalalation of a profile of CentOS 8.2:  
+* Begin the installation of a profile of CentOS 8.2:
    `# nodedeploy d4 -n centos-8.2-x86_64-default`  
    `d4: network`  
    `d4: reset`  

--- a/confluent_client/doc/man/nodediscover.ronn
+++ b/confluent_client/doc/man/nodediscover.ronn
@@ -35,8 +35,8 @@ devices.  Generally every effort is made to passively detect devices as they
 become available (as they boot or are plugged in), however sometimes an active
 scan is the best approach to catch something that appears to be missing.
 
-**nodedsicover clear** requests the server forget about a selection of
-detected device.  It takes the same arguments as **nodediscover list**.
+**nodediscover clear** requests the server to forget about a selection of
+detected devices.  It takes the same arguments as **nodediscover list**.
 
 **nodediscover subscribe** and **unsubscribe** instructs confluent to subscribe to or
 unsubscribe from the designated switch running affluent with system discovery support.

--- a/confluent_client/doc/man/nodeeventlog.ronn
+++ b/confluent_client/doc/man/nodeeventlog.ronn
@@ -20,9 +20,9 @@ noderange.
     return the last <n> entries for each node in the eventlog. 
 
 * `-t TIMEFRAME`, `--timeframe=TIMEFRAME`:
-   return entries within a specified timeframe for each node's event log. 
-   This will return entries from the last <n> hours or days. 1h would be 
-   entries from with the last one hour. 
+   return entries within a specified timeframe for each node's event log.
+   This will return entries from the last <n> hours or days. 1h would be
+   entries from within the last one hour.
                            
   
 * `-h`, `--help`:

--- a/confluent_client/doc/man/nodefirmware.ronn
+++ b/confluent_client/doc/man/nodefirmware.ronn
@@ -36,8 +36,8 @@ the out of band facilities.  Firmware updates can end in one of three states:
   When updating, prompt if more than the specified number of servers will 
   be affected  
 
-* `-p PARAMETERFILE`, `--paramaterfile=PARAMETERFILE`:
-  For updating, a parameter file to provife along with the update payload
+* `-p PARAMETERFILE`, `--parameterfile=PARAMETERFILE`:
+  For updating, a parameter file to provide along with the update payload
 
 * `-h`, `--help`:
   Show help message and exit    

--- a/confluent_client/doc/man/nodegroupdefine.ronn
+++ b/confluent_client/doc/man/nodegroupdefine.ronn
@@ -3,7 +3,7 @@ nodegroupdefine(8) -- Define new confluent node group
 
 ## SYNOPSIS
 
-`nodegroupdefine <groupname> [nodeattribute1=value1> <nodeattribute2=value2> ...]`  
+`nodegroupdefine <groupname> [<nodeattribute1=value1> <nodeattribute2=value2> ...]`
 
 ## DESCRIPTION
 
@@ -21,4 +21,4 @@ that `nodegroupattrib(8)` will error if a node group does not exist.
 
 ## SEE ALSO
 
-nodeattribexpressions(8), nodegroupattrib(8), nodegroupremove(8)
+nodeattribexpressions(5), nodegroupattrib(8), nodegroupremove(8)

--- a/confluent_client/doc/man/nodeidentify.ronn
+++ b/confluent_client/doc/man/nodeidentify.ronn
@@ -3,11 +3,11 @@ nodeidentify(8) -- Control the identify LED of confluent nodes
 
 ## SYNOPSIS
 
-`nodidentify <noderange> [on|off|blink]`  
+`nodeidentify <noderange> [on|off|blink]`
 
 ## DESCRIPTION
 
-`nodeidentify` allows you to turn on or off the location LED of conflueunt nodes,
+`nodeidentify` allows you to turn on or off the location LED of confluent nodes,
 making it easier to determine the physical location of the nodes.  The following
 options are supported:
 
@@ -24,7 +24,7 @@ options are supported:
   `n3: on`  
   `n4: on`  
 
-* Turn off the identify LED on nodes n1 thorugh n4:
+* Turn off the identify LED on nodes n1 through n4:
   `# nodeidentify n1-n4 off`  
   `n1: off`  
   `n2: off`  

--- a/confluent_client/doc/man/nodeinventory.ronn
+++ b/confluent_client/doc/man/nodeinventory.ronn
@@ -9,7 +9,7 @@ nodeinventory(8) -- Get hardware inventory of confluent node
 
 `nodeinventory` pulls information about hardware of a node.  This includes 
 information such as adapters, serial numbers, processors, and memory modules,
-as supported by the platforms hardware management implementation.  It accepts
+as supported by the platform's hardware management implementation.  It accepts
 arguments such as serial or model or others as listed above to filter
 output to specific data.
 

--- a/confluent_client/doc/man/nodel2traceroute.ronn
+++ b/confluent_client/doc/man/nodel2traceroute.ronn
@@ -1,10 +1,10 @@
-nodel2traceroute(8) -- returns the layer 2 route through an Ethernet network managed by confluent given 2 end points.
+nodel2traceroute(8) -- Returns the layer 2 route through an Ethernet network managed by confluent given 2 end points.
 ==============================
 ## SYNOPSIS
 `nodel2traceroute [options] <start_node> <end_noderange>`  
 
 ## DESCRIPTION  
-**nodel2traceroute** is a command that returns the layer 2 route for the configered interfaces in nodeattrib.
+**nodel2traceroute** is a command that returns the layer 2 route for the configured interfaces in nodeattrib.
 It can also be used with the -i and -e options to check against specific interfaces on the endpoints. If the 
 --interface or --eface option are not used then the command will check for routes against all the defined 
 interfaces in nodeattrib (net.*.switch) for the nodes.
@@ -17,7 +17,7 @@ interfaces in nodeattrib (net.*.switch) for the nodes.
 
 ## OPTIONS
 * ` -e` EFACE, --eface=INTERFACE
-   interface to check against for the second end point or end points if using checking against multiple nodes 
+   interface to check against for the second end point or end points if checking against multiple nodes
 * ` -i` INTERFACE, --interface=INTERFACE
    interface to check against for the first end point  
 * ` -c` CUMULUS, --cumulus=CUMULUS

--- a/confluent_client/doc/man/nodelicense.ronn
+++ b/confluent_client/doc/man/nodelicense.ronn
@@ -8,7 +8,7 @@ nodelicense(8) -- Manage license keys on BMC
 ## DESCRIPTION
 
 `nodelicense` manages license keys on supported BMCs. Without an argument, the command
-lists currently installed license.  Using `delete` will remove the specified license name
+lists currently installed licenses.  Using `delete` will remove the specified license name
 from the BMC.  The `save` subcommand will take the passed directory (which may be in the form
 of /path/to/{node}/ to have the node name substituted for each node) and back up installed licenses
 to that directory. The `install` command will take the specified filename and install.  The filename

--- a/confluent_client/doc/man/nodelist.ronn
+++ b/confluent_client/doc/man/nodelist.ronn
@@ -15,7 +15,7 @@ matching nodes, one line at a time.
 If a list of node attribute names are given, the value of those are also
 displayed.  If `-b` is specified, it will also display information on
 how inherited and expression based attributes are defined.  There is more
-information on node attributes in nodeattributes(5) man page.
+information on node attributes in the nodeattrib(8) man page.
 
 Attributes may be specified by wildcard, for example `net.*switch` will report
 all attributes that begin with `net.` and end with `switch`.
@@ -25,7 +25,7 @@ all attributes that begin with `net.` and end with `switch`.
 * `-b`, `--blame`:
   Annotate inherited and expression based attributes to show their base value.
 * `-d`, `--delim`:
-  Choose a delimiter to separat the values. Default - ENTER.
+  Choose a delimiter to separate the values. Default - ENTER.
 ## EXAMPLES
 * Listing matching nodes of a simple noderange:
   `# nodelist n1-n4`  
@@ -40,7 +40,7 @@ all attributes that begin with `net.` and end with `switch`.
   `n2: hardwaremanagement.manager: 172.30.3.2`  
 
 * Getting a group of attributes while determining what group defines them:
-  `# nodelist n1,n2 hardwaremanegement --blame`  
+  `# nodelist n1,n2 hardwaremanagement --blame`
   `n1: hardwaremanagement.manager: 172.30.3.1`  
   `n1: hardwaremanagement.method: ipmi (inherited from group everything)`  
   `n1: hardwaremanagement.switch: r8e1`  

--- a/confluent_client/doc/man/nodeping.ronn
+++ b/confluent_client/doc/man/nodeping.ronn
@@ -14,8 +14,8 @@ It can also be used with the `-s` flag to change the ping location to something 
 * `-h`, `--help`:  
   Show help message and exit      
 * `-s` SUBSTITUTENAME, --substitutename=SUBSTITUTENAME  
-  Use a different name other than the nodename for ping. This may be a 
-  expression, such as {bmc} or, if no { character is present, it is treated as a suffix.  -s -eth1 would make n1 become n1-eth1, for example. 
+  Use a different name other than the nodename for ping. This may be an
+  expression, such as {bmc} or, if no { character is present, it is treated as a suffix.  -s -eth1 would make n1 become n1-eth1, for example.
 
    
 ## EXAMPLES

--- a/confluent_client/doc/man/nodesensors.ronn
+++ b/confluent_client/doc/man/nodesensors.ronn
@@ -24,7 +24,7 @@ interval of 1 second is used.
   the results, which may have a different ordering than non-CSV usage of nodesensors.
 
 * `-i`, `--interval`=**SECONDS**:
-  Repeat data gathering waiting, waiting the specified time between samples.  Unless `-n` is
+  Repeat data gathering, waiting the specified time between samples.  Unless `-n` is
   specified, indefinite retrieval is assumed.
 
 * `-n`, `--numreadings`=**SAMPLES**:

--- a/confluent_client/doc/man/nodesetboot.ronn
+++ b/confluent_client/doc/man/nodesetboot.ronn
@@ -10,7 +10,7 @@ nodesetboot(8) -- Check or set next boot device for noderange
 Requests that the next boot occur from the specified device.  Unless otherwise
 specified, this is a one time boot option, and does not change the normal boot
 behavior of the system.  This is useful for taking a system that normally boots
-to the hard drive and startking a network install, or to go into the firmware
+to the hard drive and starting a network install, or to go into the firmware
 setup menu without having to hit a keystroke at the correct time on the console.
 
 Generally, it's a bit more convenient and direct to use the nodeboot(8) command,

--- a/confluent_client/doc/man/nodeshell.ronn
+++ b/confluent_client/doc/man/nodeshell.ronn
@@ -30,7 +30,7 @@ as stderr, unlike psh which combines all stdout and stderr into stdout.
 * `-p PORT`, `--port=PORT`
   Specify a custom port for ssh
 
-* `-s SUBSTITUTION`, `--substitutename=SUBSTITITUTION`
+* `-s SUBSTITUTION`, `--substitutename=SUBSTITUTION`
   Specify a substitution name instead of the nodename.  If no {} are in the substitution,
   it is considered to be an append.  For example, '-s -ib' would produce 'node1-ib' from 'node1'.
   Full expression syntax is supported, in which case the substitution is considered to be the entire

--- a/confluent_client/doc/man/stats.ronn
+++ b/confluent_client/doc/man/stats.ronn
@@ -3,7 +3,7 @@ stats(8) -- Common basic statistics on typical numeric data in output
 
 ## SYNOPSIS
 
-`<other command> | stats [-c N] [-d D] [-x|-g|-t|-o image.png] [-s N] [-v] [-b N]
+`<other command> | stats [-c N] [-d D] [-x|-g|-t|-o image.png] [-s N] [-v] [-b N]`
 
 ## DESCRIPTION
 
@@ -11,11 +11,11 @@ The **stats** command helps analyze common numerical data such as performance nu
 or temperatures or any other numerical value.
 
 By default it looks for the last numerical output on the first line to identify the numerical column
-and analyze that number. This can be overriden by **-c COLUMN** to indicate a column. By default,
+and analyze that number. This can be overridden by **-c COLUMN** to indicate a column. By default,
 whitespace and commas are treated to delimit columns, and **-d DELIMITER** can be used to override.
 
 By default it outputs basic statistics, but a histogram is available either text or through X11 output
-or sixel or output to an image file depending on whether **-x**, **-g**, **-t*, or **-o image.png** is
+or sixel or output to an image file depending on whether **-x**, **-g**, **-t**, or **-o image.png** is
 used.
 
 ## OPTIONS

--- a/confluent_osdeploy/debian/profiles/default/scripts/pre.sh
+++ b/confluent_osdeploy/debian/profiles/default/scripts/pre.sh
@@ -9,7 +9,7 @@ mgr=$(cat /etc/confluent/deployer)
 cryptboot=$(grep encryptboot: $deploycfg|sed -e 's/^encryptboot: //')
 if [ "$cryptboot" != "" ]  && [ "$cryptboot" != "none" ] && [ "$cryptboot" != "null" ]; then
    echo "****Encrypted boot requested, but not implemented for this OS, halting install" > /dev/console
-   [ -f '/tmp/autoconsdev' ] && (echo "****Encryptod boot requested, but not implemented for this OS,halting install" >> $(cat /tmp/autoconsdev))
+   [ -f '/tmp/autoconsdev' ] && (echo "****Encrypted boot requested, but not implemented for this OS, halting install" >> $(cat /tmp/autoconsdev))
    while :; do sleep 86400; done
 fi
 cat > /usr/lib/live-installer.d/confluent-certs << EOF

--- a/confluent_osdeploy/el10-diskless/initramfs/usr/lib/dracut/hooks/cmdline/10-confluentdiskless.sh
+++ b/confluent_osdeploy/el10-diskless/initramfs/usr/lib/dracut/hooks/cmdline/10-confluentdiskless.sh
@@ -143,8 +143,8 @@ while [ $ready = "0" ]; do
     elif grep 'SSL' $tmperr > /dev/null; then
         confluent_mgr=${confluent_mgr#[}
         confluent_mgr=${confluent_mgr%]}
-    	echo 'Failure establishing TLS conneection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)'
-	if [ ! -z "$autoconsdev" ]; then echo 'Failure establishing TLS conneection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)' > $autoconsdev; fi
+    	echo 'Failure establishing TLS connection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)'
+	if [ ! -z "$autoconsdev" ]; then echo 'Failure establishing TLS connection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)' > $autoconsdev; fi
     	sleep 10
     else
         ready=1

--- a/confluent_osdeploy/el8-diskless/initramfs/usr/lib/dracut/hooks/cmdline/10-confluentdiskless.sh
+++ b/confluent_osdeploy/el8-diskless/initramfs/usr/lib/dracut/hooks/cmdline/10-confluentdiskless.sh
@@ -174,8 +174,8 @@ while [ $ready = "0" ]; do
     elif grep 'SSL' $tmperr > /dev/null; then
         confluent_mgr=${confluent_mgr#[}
         confluent_mgr=${confluent_mgr%]}
-    	echo 'Failure establishing TLS conneection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)'
-	if [ ! -z "$autoconsdev" ]; then echo 'Failure establishing TLS conneection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)' > $autoconsdev; fi
+    	echo 'Failure establishing TLS connection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)'
+	if [ ! -z "$autoconsdev" ]; then echo 'Failure establishing TLS connection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)' > $autoconsdev; fi
     	sleep 10
     else
         ready=1

--- a/confluent_osdeploy/el9-diskless/initramfs/usr/lib/dracut/hooks/cmdline/10-confluentdiskless.sh
+++ b/confluent_osdeploy/el9-diskless/initramfs/usr/lib/dracut/hooks/cmdline/10-confluentdiskless.sh
@@ -145,8 +145,8 @@ while [ $ready = "0" ]; do
     elif grep 'SSL' $tmperr > /dev/null; then
         confluent_mgr=${confluent_mgr#[}
         confluent_mgr=${confluent_mgr%]}
-    	echo 'Failure establishing TLS conneection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)'
-	if [ ! -z "$autoconsdev" ]; then echo 'Failure establishing TLS conneection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)' > $autoconsdev; fi
+    	echo 'Failure establishing TLS connection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)'
+	if [ ! -z "$autoconsdev" ]; then echo 'Failure establishing TLS connection to '$confluent_mgr' (try `osdeploy initialize -t` on the deployment server)' > $autoconsdev; fi
     	sleep 10
     else
         ready=1

--- a/confluent_osdeploy/suse15/profiles/hpc/scripts/pre.sh
+++ b/confluent_osdeploy/suse15/profiles/hpc/scripts/pre.sh
@@ -15,7 +15,7 @@ fi
 cryptboot=$(grep encryptboot: /etc/confluent/confluent.deploycfg|sed -e 's/^encryptboot: //')
 if [ "$cryptboot" != "" ]  && [ "$cryptboot" != "none" ] && [ "$cryptboot" != "null" ]; then
    echo "****Encrypted boot requested, but not implemented for this OS, halting install" > /dev/console
-   [ -f '/tmp/autoconsdev' ] && (echo "****Encryptod boot requested, but not implemented for this OS,halting install" >> $(cat /tmp/autoconsdev))
+   [ -f '/tmp/autoconsdev' ] && (echo "****Encrypted boot requested, but not implemented for this OS, halting install" >> $(cat /tmp/autoconsdev))
    while :; do sleep 86400; done
 fi
 

--- a/confluent_osdeploy/suse15/profiles/server/scripts/pre.sh
+++ b/confluent_osdeploy/suse15/profiles/server/scripts/pre.sh
@@ -15,7 +15,7 @@ fi
 cryptboot=$(grep encryptboot: /etc/confluent/confluent.deploycfg|sed -e 's/^encryptboot: //')
 if [ "$cryptboot" != "" ]  && [ "$cryptboot" != "none" ] && [ "$cryptboot" != "null" ]; then
    echo "****Encrypted boot requested, but not implemented for this OS, halting install" > /dev/console
-   [ -f '/tmp/autoconsdev' ] && (echo "****Encryptod boot requested, but not implemented for this OS,halting install" >> $(cat /tmp/autoconsdev))
+   [ -f '/tmp/autoconsdev' ] && (echo "****Encrypted boot requested, but not implemented for this OS, halting install" >> $(cat /tmp/autoconsdev))
    while :; do sleep 86400; done
 fi
 

--- a/confluent_osdeploy/ubuntu18.04/profiles/default/scripts/pre.sh
+++ b/confluent_osdeploy/ubuntu18.04/profiles/default/scripts/pre.sh
@@ -9,7 +9,7 @@ mgr=$(cat /etc/confluent/deployer)
 cryptboot=$(grep encryptboot: $deploycfg|sed -e 's/^encryptboot: //')
 if [ "$cryptboot" != "" ]  && [ "$cryptboot" != "none" ] && [ "$cryptboot" != "null" ]; then
    echo "****Encrypted boot requested, but not implemented for this OS, halting install" > /dev/console
-   [ -f '/tmp/autoconsdev' ] && (echo "****Encryptod boot requested, but not implemented for this OS,halting install" >> $(cat /tmp/autoconsdev))
+   [ -f '/tmp/autoconsdev' ] && (echo "****Encrypted boot requested, but not implemented for this OS, halting install" >> $(cat /tmp/autoconsdev))
    while :; do sleep 86400; done
 fi
 cat > /usr/lib/live-installer.d/confluent-certs << EOF

--- a/confluent_osdeploy/ubuntu20.04/profiles/default/scripts/pre.sh
+++ b/confluent_osdeploy/ubuntu20.04/profiles/default/scripts/pre.sh
@@ -15,7 +15,7 @@ chmod 600 /var/log/confluent/confluent-pre.log
 cryptboot=$(grep encryptboot: $deploycfg|sed -e 's/^encryptboot: //')
 if [ "$cryptboot" != "" ]  && [ "$cryptboot" != "none" ] && [ "$cryptboot" != "null" ]; then
    echo "****Encrypted boot requested, but not implemented for this OS, halting install" > /dev/console
-   [ -f '/tmp/autoconsdev' ] && (echo "****Encryptod boot requested, but not implemented for this OS,halting install" >> $(cat /tmp/autoconsdev))
+   [ -f '/tmp/autoconsdev' ] && (echo "****Encrypted boot requested, but not implemented for this OS, halting install" >> $(cat /tmp/autoconsdev))
    while :; do sleep 86400; done
 fi
 

--- a/confluent_osdeploy/ubuntu22.04/profiles/default/scripts/pre.sh
+++ b/confluent_osdeploy/ubuntu22.04/profiles/default/scripts/pre.sh
@@ -49,8 +49,8 @@ if [ "$cryptboot" != "" ]  && [ "$cryptboot" != "none" ] && [ "$cryptboot" != "n
     export lukspass
     run_remote_python addcrypt
     if ! grep 'password:' /autoinstall.yaml > /dev/null; then
-        echo "****Encrypted boot requested, but the user-data does not have a hook to enable,halting install" > /dev/console
-        [ -f '/tmp/autoconsdev' ] && (echo "****Encryptod boot requested, but the user-data does not have a hook to enable,halting install" >> $(cat /tmp/autoconsdev))
+        echo "****Encrypted boot requested, but the user-data does not have a hook to enable, halting install" > /dev/console
+        [ -f '/tmp/autoconsdev' ] && (echo "****Encrypted boot requested, but the user-data does not have a hook to enable, halting install" >> $(cat /tmp/autoconsdev))
         while :; do sleep 86400; done
     fi
     sed -i s!%%CRYPTPASS%%!$lukspass! /autoinstall.yaml

--- a/confluent_perl/Confluent/Client.pm
+++ b/confluent_perl/Confluent/Client.pm
@@ -61,7 +61,7 @@ sub _verify {
         $knownhosts{$peername} = $addfingerprint;
     }
     if (not $knownhosts{$peername}) {
-        die "UKNNOWN_FINGERPRINT: fingerprint=>$fingerprint"
+        die "UNKNOWN_FINGERPRINT: fingerprint=>$fingerprint"
     }
     if ($fingerprint ne $knownhosts{$peername}) {
         die "CONFLICT_FINGERPRINT: fingerprint=>$fingerprint";

--- a/confluent_server/confluent/collective/manager.py
+++ b/confluent_server/confluent/collective/manager.py
@@ -533,7 +533,7 @@ async def handle_connection(connection, cert, request, local=False):
             return
         if request['txcount'] < cfm._txcount:
             await tlvdata.send(connection,
-                         {'error': 'Refusing to be assimilated by inferior'
+                         {'error': 'Refusing to be assimilated by inferior '
                                    'transaction count',
                           'txcount': cfm._txcount,})
             return
@@ -637,7 +637,7 @@ async def handle_connection(connection, cert, request, local=False):
         if request['txcount'] > cfm._txcount:
             await retire_as_leader()
             await tlvdata.send(connection,
-                         {'error': 'Client has higher tranasaction count, '
+                         {'error': 'Client has higher transaction count, '
                                    'should assimilate me, connecting..',
                           'txcount': cfm._txcount})
             log.log({'info': 'Connecting to leader due to superior '
@@ -763,7 +763,7 @@ async def get_leader(connection):
             msg = 'Becoming leader as no leader known'
         else:
             msg = 'Becoming leader because {0} attempted to connect and it ' \
-                  'is current leader'.format(currentleader)
+                  'is the current leader'.format(currentleader)
         log.log({'info': msg, 'subsystem': 'collective'})
         await become_leader(connection)
     return currentleader

--- a/confluent_server/confluent/config/attributes.py
+++ b/confluent_server/confluent/config/attributes.py
@@ -247,7 +247,7 @@ node = {
 
     },
     'deployment.state': {
-        'description': ('Profiles may push more specific state, for example, it may set the state to "failed" or "succeded"'),
+        'description': ('Profiles may push more specific state, for example, it may set the state to "failed" or "succeeded"'),
     },
     'deployment.state_detail': {
         'description': ('Detailed state information as reported by an OS profile, when available'),
@@ -268,7 +268,7 @@ node = {
         'description':  'Any specified rules shall be configured on the BMC '
                         'upon discovery.  "expiration=no,loginfailures=no,complexity=no,reuse=no" '
                         'would disable password expiration, login failures '
-                        'triggering a lockout, password complexity requirements,'
+                        'triggering a lockout, password complexity requirements, '
                         'and any restrictions around reusing an old password.',
         'validlistkeys': ('expiration', 'loginfailures', 'complexity', 'reuse'),
     },
@@ -487,7 +487,7 @@ node = {
                        'the discovery process to decide where to place the mac address of a detected PXE nic.',
     },
     'net.connection_name': {
-        'description': 'Name to use when specifiying a name for connection and/or interface name for a team/bond.  This may be the name of a team/bond interface, '
+        'description': 'Name to use when specifying a name for connection and/or interface name for a team/bond.  This may be the name of a team/bond interface, '
                        'the connection name in network manager for the interface, or may be installed as an altname '
                        'as supported by the respective OS deployment profiles.  Default is to accept default name for '
                        'a team/bond consistent with the respective OS, or to use the matching original port name as connection name.'
@@ -593,7 +593,7 @@ node = {
         'description': 'Specifies the managed PDU associated with a power input on the node'
     },
     'power.outlet': {
-        'description': 'Species the outlet identifier on the PDU associoted with a power input on the node'
+        'description': 'Specifies the outlet identifier on the PDU associated with a power input on the node'
     },
 #    'id.modelnumber': {
 #        'description': 'The manufacturer dictated  model number for the node',
@@ -614,7 +614,7 @@ node = {
         'description': 'A one-time use shared secret to authenticate a node api token',
     },
     'secret.snmpcommunity': {
-        'description': ('SNMPv1 community string, it is highly recommended to'
+        'description': ('SNMPv1 community string, it is highly recommended to '
                         'step up to SNMPv3'),
     },
     'snmp.privacyprotocol': {
@@ -676,7 +676,7 @@ node = {
         'validvalues': ('tofu', 'manual', 'ca', 'ca-only'),
     },
     'pubkeys.tls_hardwaremanager': {
-        'description':  ('Fingerprint of the TLS certificate recognized as'
+        'description':  ('Fingerprint of the TLS certificate recognized as '
                          'belonging to the hardware manager of the server'),
     },
     'pubkeys.tls': {

--- a/confluent_server/confluent/core.py
+++ b/confluent_server/confluent/core.py
@@ -1349,7 +1349,7 @@ async def dispatch_request(nodes, manager, element, configmanager, inputdata,
         if isinstance(rsp, Exception):
             raise rsp
         if not rsp:
-            raise Exception('Error in cross-collective serialize/deserialze, see remote logs')
+            raise Exception('Error in cross-collective serialize/deserialize, see remote logs')
         yield rsp
 
 

--- a/confluent_server/confluent/discovery/core.py
+++ b/confluent_server/confluent/discovery/core.py
@@ -895,7 +895,7 @@ async def detected(info):
             rechecktime = util.monotonic_time() + 300
             rechecker = tasks.spawn_task_after(300, _periodic_recheck, cfg)
         unknown_info[info['hwaddr']] = info
-        info['discostatus'] = 'unidentfied'
+        info['discostatus'] = 'unidentified'
         #TODO, spawn after to recheck sooner, or somehow else
         # influence periodic recheck to shorten delay?
         return

--- a/confluent_server/confluent/discovery/core.py
+++ b/confluent_server/confluent/discovery/core.py
@@ -1285,7 +1285,7 @@ async def eval_node(cfg, handler, info, nodename, manual=False):
         # might be ambiguous, need to match chassis-uuid as well..
         match = await search_smms_by_cert(nodename, await handler.get_https_cert(), cfg)
         if match:
-            info['verfied'] = True
+            info['verified'] = True
             info['enclosure.bay'] = match[1]
             if match[2]:
                 if not await discover_node(cfg, handler, info, match[2], manual):

--- a/confluent_server/confluent/discovery/core.py
+++ b/confluent_server/confluent/discovery/core.py
@@ -1258,7 +1258,7 @@ async def eval_node(cfg, handler, info, nodename, manual=False):
     except Exception as e:
         unknown_info[info['hwaddr']] = info
         info['discostatus'] = 'unidentified'
-        errorstr = 'An error occured during discovery, check the ' \
+        errorstr = 'An error occurred during discovery, check the ' \
                    'trace and stderr logs, mac was {0} and ip was {1}' \
                    ', the node or the containing enclosure was {2}' \
                    ''.format(info['hwaddr'], handler.ipaddr, nodename)
@@ -1505,7 +1505,7 @@ async def discover_node(cfg, handler, info, nodename, manual):
                 bmcaddr = cfg.get_node_attributes(nodename, 'hardwaremanagement.manager')
                 bmcaddr = bmcaddr.get(nodename, {}).get('hardwaremanagement.manager', {}).get('value', '')
                 if not bmcaddr:
-                    log.log({'error': 'Unable to get BMC address for {0]'.format(nodename)})
+                    log.log({'error': 'Unable to get BMC address for {0}'.format(nodename)})
                 else:
                     bmcaddr = bmcaddr.split('/', 1)[0]
                     await wait_for_connection(bmcaddr)

--- a/confluent_server/confluent/discovery/handlers/xcc.py
+++ b/confluent_server/confluent/discovery/handlers/xcc.py
@@ -540,7 +540,7 @@ class NodeHandler(immhandler.NodeHandler):
                     if not nwc:
                         if not pwdchanged:
                             pwdchanged = 'Unknown'
-                        raise Exception('Error converting from sha356account: ' + repr(pwdchanged))
+                        raise Exception('Error converting from sha256account: ' + repr(pwdchanged))
                     if not pwdchanged:
                         await nwc.grab_json_response(
                             '/api/function',

--- a/confluent_server/confluent/discovery/protocols/pxe.py
+++ b/confluent_server/confluent/discovery/protocols/pxe.py
@@ -784,7 +784,7 @@ async def reply_dhcp4(node, info, packet, cfg, reqview, httpboot, cfd, profile, 
             if not profile:
                 profile, stgprofile = get_deployment_profile(node, cfg)
             if not profile:
-                log.log({'info': 'No pending profile for {0}, skipping proxyDHCP eply'.format(node)})
+                log.log({'info': 'No pending profile for {0}, skipping proxyDHCP reply'.format(node)})
                 return
             bootfile = 'http://{0}/confluent-public/os/{1}/boot.ipxe'.format(myipn, profile).encode('utf8')
         else:

--- a/confluent_server/confluent/log.py
+++ b/confluent_server/confluent/log.py
@@ -232,7 +232,7 @@ class TimedAndSizeRotatingFileHandler(BaseRotatingHandler):
         if self.maxBytes < 8192:
             raise exc.GlobalConfigError("The minimum value of max_bytes "
                                         "of log rolling size in the log "
-                                        "section should larger than 8192.")
+                                        "section should be larger than 8192.")
         self.utc = conf.get_boolean_option('log', 'utc') or False
 
         # Calculate the real rollover interval, which is just the number of

--- a/confluent_server/confluent/plugins/hardwaremanagement/enlogic.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/enlogic.py
@@ -48,7 +48,7 @@ class EnlogicClient(object):
         if self._wc:
             print("done cache")
             return self._wc
-        print("loggin")
+        print("logging")
         targcfg = self.configmanager.get_node_attributes(
             self.node, ['hardwaremanagement.manager'], decrypt=True
         )

--- a/confluent_server/confluent/plugins/hardwaremanagement/proxmox.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/proxmox.py
@@ -306,7 +306,7 @@ class PmxApiClient:
             return 'on'
         elif currstatus == 'stopped':
             return 'off'
-        raise Exception("Unknnown response to status query")
+        raise Exception("Unknown response to status query")
 
     async def set_vm_power(self, vm, state):
         host, guest = await self.get_vm(vm)

--- a/confluent_server/confluent/webauthn.py
+++ b/confluent_server/confluent/webauthn.py
@@ -134,7 +134,7 @@ class User():
 def registration_request(username, cfg, APP_RELYING_PARTY):
     user_model = User.get(username)
     if user_model is None:
-        raise Exception("User not foud")
+        raise Exception("User not found")
 
     options = generate_registration_options(
         rp_name=APP_RELYING_PARTY.name,

--- a/genesis/confluent-genesis.spec
+++ b/genesis/confluent-genesis.spec
@@ -11,7 +11,7 @@ AutoProv: false
 License: Various
 
 %Description
-A small linux environment to proved a servicing image to boot systems into if needed.
+A small linux environment to provide a servicing image to boot systems into if needed.
 
 %prep
 


### PR DESCRIPTION
- Fix spelling/grammar in man pages, CLI help text, error/warning messages, and log output across

- Fix a few small bugs surfaced while reviewing that text (separate commits):
  - `discovery/core.py`: `'unidentfied'` → `'unidentified'` — the typo hid affected records from the `unidentified/` discovery filter
  - `discovery/core.py`: `info['verfied']` → `info['verified']` — the typo silently dropped verification state for one enclosure-matching code path
  - `confluent2hosts`: removed a stray unconditional write to `/etc/whatnowhosts` left over from debugging
  - `nodel2traceroute`: fixed a missing `.format()` call that printed `{0}` literally instead of the interface name