### PR TITLE
License naming fixes for EPEL

### DIFF
--- a/confluent_client/confluent_client.spec.tmpl
+++ b/confluent_client/confluent_client.spec.tmpl
@@ -11,7 +11,7 @@ Name: %{name}
 Version: %{version}
 Release: %{release}
 Source0: %{name}-%{fversion}.tar.gz
-License: Apache2
+License: Apache-2.0
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}

--- a/confluent_osdeploy/confluent_osdeploy-aarch64.spec.tmpl
+++ b/confluent_osdeploy/confluent_osdeploy-aarch64.spec.tmpl
@@ -3,7 +3,7 @@ Version: #VERSION#
 Release: 1
 Summary: OS Deployment support for confluent
 
-License: Apache2
+License: Apache-2.0
 URL: https://hpc.lenovo.com/
 Source0: confluent_osdeploy.tar.xz
 Source1: confluent_el9bin.tar.xz

--- a/confluent_osdeploy/confluent_osdeploy.spec.tmpl
+++ b/confluent_osdeploy/confluent_osdeploy.spec.tmpl
@@ -3,7 +3,7 @@ Version: #VERSION#
 Release: 1
 Summary: OS Deployment support for confluent
 
-License: Apache2
+License: Apache-2.0
 URL: https://hpc.lenovo.com/
 Source0: confluent_osdeploy.tar.xz
 Source1: confluent_el9bin.tar.xz

--- a/confluent_server/confluent_server.spec.tmpl
+++ b/confluent_server/confluent_server.spec.tmpl
@@ -11,7 +11,7 @@ Name: %{name}
 Version: %{version}
 Release: %{release}
 Source0: %{name}-%{fversion}.tar.gz
-License: Apache2
+License: Apache-2.0
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}

--- a/confluent_vtbufferd/confluent_vtbufferd.spec.tmpl
+++ b/confluent_vtbufferd/confluent_vtbufferd.spec.tmpl
@@ -9,7 +9,7 @@ Name: %{name}
 Version: %{version}
 Release: %{release}
 Source0: %{name}-%{version}.tar.gz
-License: Apache2
+License: Apache-2.0
 Group: Development/Libraries
 Vendor: Lenovo HPC Organization <hpchelp@lenovo.com>
 Url: https://github.com/lenovo/confluent/

--- a/confluent_vtbufferd/confluent_vtbufferd.spec.tmpl
+++ b/confluent_vtbufferd/confluent_vtbufferd.spec.tmpl
@@ -9,7 +9,7 @@ Name: %{name}
 Version: %{version}
 Release: %{release}
 Source0: %{name}-%{version}.tar.gz
-License: Apache-2.0
+License: Apache-2.0 AND BSD-3-Clause
 Group: Development/Libraries
 Vendor: Lenovo HPC Organization <hpchelp@lenovo.com>
 Url: https://github.com/lenovo/confluent/

--- a/imgutil/confluent_imgutil.spec.tmpl
+++ b/imgutil/confluent_imgutil.spec.tmpl
@@ -2,7 +2,7 @@ Name: confluent_imgutil
 Version: #VERSION#
 Release: 1
 Summary: Confluent OS imaging utility
-License: Apache2
+License: Apache-2.0
 URL: https://hpc.lenovo.com/
 Source: confluent_imgutil.tar.xz
 BuildArch: noarch


### PR DESCRIPTION
Just a small PR to make confluent ready for EPEL.

For EPEL the official SPDX license expressions have to be used.
Check:

- https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
- https://spdx.org/licenses/
- https://docs.fedoraproject.org/en-US/legal/allowed-licenses/

On top of that, add the missing BSD-3-Clause license of https://github.com/xcat2/confluent/blob/master/confluent_vtbufferd/tmt.c.
It's BSD-3-Clause as described in https://github.com/xcat2/confluent/blob/master/confluent_vtbufferd/NOTICE, too.