### PR TITLE
Add Dell iDRAC support: discovery, service tag collection, and iDRAC attribute configuration

### DIFF
--- a/confluent_server/aiohmi/redfish/oem/dell/idrac.py
+++ b/confluent_server/aiohmi/redfish/oem/dell/idrac.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import aiohmi.exceptions as exc
 import aiohmi.redfish.oem.generic as generic
 
 
 class OEMHandler(generic.OEMHandler):
 
-    def set_bootdev(self, bootdev, persist=False, uefiboot=None,
+    def __init__(self):
+        super(OEMHandler, self).__init__()
+        # attribute name -> owning DellAttributes resource URL, populated
+        # by get_bmc_configuration and required by set_bmc_configuration
+        # to route each change to the correct resource
+        self._attrurlbyname = {}
+
+    async def set_bootdev(self, bootdev, persist=False, uefiboot=None,
                     fishclient=None):
         # gleaned from web console, under configuration, system settings,
         # hardware, first boot device. iDrac presumes that the standard
@@ -26,8 +34,8 @@ class OEMHandler(generic.OEMHandler):
         # the 'physical' standard to the vFDD/VCD-DVD seen in the idrac
         # web gui
         if bootdev not in ('floppy', 'cd'):
-            return super(OEMHandler, self).set_bootdev(bootdev, persist,
-                                                       uefiboot, fishclient)
+            return await super(OEMHandler, self).set_bootdev(
+                bootdev, persist, uefiboot, fishclient)
         payload = {'Attributes': {}}
         if persist:
             payload['Attributes']['ServerBoot.1.BootOnce'] = 'Disabled'
@@ -37,7 +45,71 @@ class OEMHandler(generic.OEMHandler):
             payload['Attributes']['ServerBoot.1.FirstBootDevice'] = 'vFDD'
         elif bootdev == 'cd':
             payload['Attributes']['ServerBoot.1.FirstBootDevice'] = 'VCD-DVD'
-        fishclient._do_web_request(
+        await fishclient._do_web_request(
             '/redfish/v1/Managers/iDRAC.Embedded.1/Attributes',
-            payload, method='PATCH')
+            payload, method='PATCH', etag='*')
         return {'bootdev': bootdev}
+
+    async def _get_attribute_urls(self):
+        # The iDRAC exposes its configuration as three OEM attribute
+        # resources (iDRAC, System, and LifecycleController scopes),
+        # linked from the manager via Links.Oem.Dell.DellAttributes
+        mgrurl = await self.get_default_mgrurl()
+        mgrinfo = await self._do_web_request(mgrurl)
+        atturls = []
+        dellattrs = mgrinfo.get('Links', {}).get('Oem', {}).get(
+            'Dell', {}).get('DellAttributes', [])
+        for attmember in dellattrs:
+            atturl = attmember.get('@odata.id', None)
+            if atturl:
+                atturls.append(atturl)
+        if not atturls:
+            # older firmware without the DellAttributes links; the manager
+            # scope attributes are still available at a fixed location
+            atturls = [mgrurl + '/Attributes']
+        return atturls
+
+    async def get_bmc_configuration(self):
+        settings = {}
+        self._attrurlbyname = {}
+        for atturl in await self._get_attribute_urls():
+            attrs = await self._do_web_request(atturl)
+            for attname in attrs.get('Attributes', {}):
+                settings[attname] = {
+                    'value': attrs['Attributes'][attname]}
+                self._attrurlbyname[attname] = atturl
+        return settings
+
+    async def set_bmc_configuration(self, changeset):
+        if not self._attrurlbyname:
+            currsettings = await self.get_bmc_configuration()
+        else:
+            currsettings = None
+        updates = {}
+        for key in changeset:
+            currval = changeset[key]
+            if isinstance(currval, dict):
+                currval = currval.get('value', None)
+            attrurl = self._attrurlbyname.get(key, None)
+            if not attrurl:
+                raise exc.InvalidParameterValue(
+                    'Unknown attribute {0}'.format(key))
+            if attrurl not in updates:
+                updates[attrurl] = {}
+            updates[attrurl][key] = currval
+        # attributes are typed in the iDRAC; values arrive as strings from
+        # the caller, so coerce integers by the type of the current value
+        if currsettings is None:
+            currsettings = await self.get_bmc_configuration()
+        for attrurl in updates:
+            for key in updates[attrurl]:
+                currtype = type(currsettings.get(key, {}).get('value', ''))
+                if currtype is int and isinstance(updates[attrurl][key], str):
+                    try:
+                        updates[attrurl][key] = int(updates[attrurl][key])
+                    except ValueError:
+                        pass
+            await self._do_web_request(
+                attrurl, {'Attributes': updates[attrurl]}, method='PATCH',
+                etag='*')
+            self._invalidate_url_cache(attrurl)

--- a/confluent_server/confluent/discovery/core.py
+++ b/confluent_server/confluent/discovery/core.py
@@ -78,6 +78,7 @@ import confluent.discovery.handlers.xcc as xcc
 import confluent.discovery.handlers.xcc3 as xcc3
 import confluent.discovery.handlers.smm3 as smm3
 import confluent.discovery.handlers.megarac as megarac
+import confluent.discovery.handlers.dell as dell
 import confluent.discovery.handlers.eureka as eureka
 import confluent.exceptions as exc
 import confluent.log as log
@@ -122,6 +123,7 @@ nodehandlers = {
     'lenovo-xcc': xcc,
     'lenovo-xcc3': xcc3,
     'megarac-bmc': megarac,
+    'dell-idrac': dell,
     'megware-chassis': eureka,
     'service:management-hardware.IBM:integrated-management-module2': imm,
     'pxe-client': pxeh,
@@ -145,6 +147,7 @@ servicenames = {
     'lenovo-xcc': 'lenovo-xcc',
     'lenovo-xcc3': 'lenovo-xcc3',
     'megarac-bmc': 'megarac-bmc',
+    'dell-idrac': 'dell-idrac',
     'megware-chassis': 'megware-chassis',
     #'openbmc': 'openbmc',
     'service:management-hardware.IBM:integrated-management-module2': 'lenovo-imm2',
@@ -164,6 +167,7 @@ servicebyname = {
     'lenovo-xcc': 'lenovo-xcc',
     'lenovo-xcc3': 'lenovo-xcc3',
     'megarac-bmc': 'megarac-bmc',
+    'dell-idrac': 'dell-idrac',
     'megware-chassis': 'megware-chassis',
     'lenovo-imm2': 'service:management-hardware.IBM:integrated-management-module2',
     'lenovo-switch': 'service:io-device.Lenovo:management-module',

--- a/confluent_server/confluent/discovery/handlers/dell.py
+++ b/confluent_server/confluent/discovery/handlers/dell.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Lenovo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import confluent.discovery.handlers.redfishbmc as redfishbmc
+
+import aiohmi.util.webclient as webclient
+
+
+class NodeHandler(redfishbmc.NodeHandler):
+    devname = 'iDRAC'
+
+    def get_firmware_default_account_info(self):
+        # Factory default for iDRAC; systems shipped with a unique
+        # per-system password will have the actual password provided
+        # via the normal credential attributes instead.
+        return ('root', 'calvin')
+
+    async def scan(self):
+        # In addition to the UUID gathered by the generic redfish scan,
+        # iDRAC exposes the Dell service tag (the serial number of the
+        # system) unauthenticated at the service root, so gather it here
+        # to enable discovery matching and id.serial by service tag.
+        await self.get_https_cert()
+        c = webclient.WebConnection(self.ipaddr, 443,
+                                    verifycallback=self.validate_cert)
+        i = await c.grab_json_response('/redfish/v1/')
+        uuid = i.get('UUID', None)
+        if uuid:
+            self.info['uuid'] = uuid.lower()
+        servicetag = i.get('Oem', {}).get('Dell', {}).get('ServiceTag', None)
+        if servicetag:
+            self.info['serialnumber'] = servicetag
+
+
+async def remote_nodecfg(nodename, cfm):
+    cfg = cfm.get_node_attributes(
+            nodename, 'hardwaremanagement.manager')
+    ipaddr = cfg.get(nodename, {}).get('hardwaremanagement.manager', {}).get(
+        'value', None)
+    ipaddr = ipaddr.split('/', 1)[0]
+    ipaddr = (await asyncio.get_running_loop().getaddrinfo(ipaddr, 0))[0][-1]
+    if not ipaddr:
+        raise Exception('Cannot remote configure a system without known '
+                        'address')
+    info = {'addresses': [ipaddr]}
+    nh = NodeHandler(info, cfm)
+    await nh.config(nodename)
+
+
+if __name__ == '__main__':
+    import confluent.config.configmanager as cfm
+    c = cfm.ConfigManager(None)
+    import sys
+    info = {'addresses': [[sys.argv[1]]]}
+    print(repr(info))
+    testr = NodeHandler(info, c)
+    testr.config(sys.argv[2])

--- a/confluent_server/confluent/discovery/protocols/ssdp.py
+++ b/confluent_server/confluent/discovery/protocols/ssdp.py
@@ -466,16 +466,22 @@ async def _find_service(service, target):
         elif '/redfish/v1/' not in peerdata[nid].get('urls', ()) and '/redfish/v1' not in peerdata[nid].get('urls', ()):
             continue
         else:
+            isxml = False
             for targurl in peerdata[nid]['urls']:
                 if targurl and targurl.endswith('.xml'):
+                    isxml = True
                     pooltargs.append(('/redfish/v1/', peerdata[nid], 'megarac-bmc'))
-        # For now, don't interrogate generic redfish bmcs
+            if not isxml:
+                # Interrogate the service root solely to recognize vendors
+                # with an explicit handler (e.g. Dell iDRAC); check_fish
+                # will not claim unrecognized vendors for this targtype,
+                # preserving the deduplication described below.
+                pooltargs.append(('/redfish/v1/', peerdata[nid], 'redfish-server'))
+        # For now, don't claim generic redfish bmcs
         # This is due to a need to deduplicate from some supported SLP
         # targets (IMM, TSM, others)
-        # activate this else once the core filters/merges duplicate uuid
-        # or we drop support for those devices
-        #else:
-        #    pooltargs.append(('/redfish/v1/', peerdata[nid]))
+        # activate claiming of generic redfish once the core filters/merges
+        # duplicate uuid or we drop support for those devices
     tsks = []
     for targ in pooltargs:
         tsks.append(tasks.spawn_task(check_fish(targ)))
@@ -486,6 +492,32 @@ async def _find_service(service, target):
             if dt is None:
                 continue
             yield dt
+
+def _vendor_from_fishroot(peerinfo, data):
+    """Identify a device by the Vendor field of its redfish service root.
+
+    Returns the augmented peer data for vendors that have an explicit
+    discovery handler, or None for unrecognized vendors, which must not
+    be claimed (they may duplicate SLP-discovered IMM/TSM targets).
+    """
+    if not peerinfo or 'UUID' not in peerinfo:
+        return None
+    vendor = peerinfo.get('Vendor', '')
+    if vendor == 'Megware':
+        data['services'] = ['megware-chassis']
+    elif vendor == 'Dell':
+        data['services'] = ['dell-idrac']
+        # iDRAC exposes the service tag (system serial number)
+        # unauthenticated at the service root
+        servicetag = peerinfo.get('Oem', {}).get('Dell', {}).get(
+            'ServiceTag', None)
+        if servicetag:
+            data['serialnumber'] = servicetag
+    else:
+        return None
+    data['uuid'] = peerinfo['UUID'].lower()
+    return data
+
 
 async def check_fish(urldata, port=443, verifycallback=None):
     if not verifycallback:
@@ -503,11 +535,16 @@ async def check_fish(urldata, port=443, verifycallback=None):
     if url == '/DeviceDescription.json':
         if not peerinfo:
             if data.get('services', None) == ['urn::dmtf-org:service:redfish-rest:']:
-                peerinfo = wc.grab_json_response('/redfish/v1/')
+                peerinfo = await wc.grab_json_response('/redfish/v1/')
                 if peerinfo:
                     data['services'] = ['lenovo-smm3']
                     data['uuid'] = peerinfo['UUID'].lower()
                     return data
+            if targtype == 'redfish-server':
+                # No DeviceDescription.json; may still be a vendor
+                # recognizable from the service root (e.g. Dell iDRAC)
+                peerinfo = await wc.grab_json_response('/redfish/v1/')
+                return _vendor_from_fishroot(peerinfo, data)
             return None
         try:
             peerinfo = peerinfo[0]
@@ -544,12 +581,14 @@ async def check_fish(urldata, port=443, verifycallback=None):
             peerinfo = await wc.grab_json_response('/redfish/v1/')
     if url == '/redfish/v1/':
         if 'UUID' in peerinfo:
-            vendor = peerinfo.get('Vendor', '')
-            # NOTE: Specific path for EUREKA MEGWARE Chassis
-            if vendor == 'Megware':
-                data['services'] = ['megware-chassis']
-            else:
-                data['services'] = [targtype]
+            vdata = _vendor_from_fishroot(peerinfo, data)
+            if vdata:
+                return vdata
+            if targtype == 'redfish-server':
+                # Unrecognized vendor; do not claim generic redfish
+                # (deduplication with SLP-discovered targets)
+                return None
+            data['services'] = [targtype]
             data['uuid'] = peerinfo['UUID'].lower()
             return data
     return None


### PR DESCRIPTION
Adds Dell system support to confluent. The aiohmi Dell OEM handler already existed but iDRACs were never discovered, and the OEM handler had been left behind by the asyncio port.

**Discovery** (`discovery: add Dell iDRAC support`)
- New `dell-idrac` discovery handler subclassing the generic redfishbmc handler, with iDRAC factory defaults (root/calvin). `scan()` collects the Dell service tag from the unauthenticated service root (`Oem.Dell.ServiceTag`) so `id.serial` is populated at discovery time.
- iDRACs advertise a plain `/redfish/v1/` LOCATION over SSDP and were classed as generic `redfish-server`, which is deliberately never claimed (dedup with SLP-discovered IMM/TSM). The service root of such devices is now interrogated and claimed **only** when the `Vendor` field matches a vendor with an explicit handler (Dell, plus the existing Megware case, factored into a shared `_vendor_from_fishroot`). Unrecognized vendors are still not claimed, so the existing dedup behaviour is preserved. Covers both active scan and passive snoop paths.
- Drive-by fix: missing `await` on `grab_json_response` in the smm3 fallback of `check_fish`.

**Management** (`aiohmi/dell: fix async set_bootdev, add iDRAC attribute configuration`)
- `set_bootdev` was still synchronous from before the asyncio port and never awaited its PATCH; now async with `etag='*'`.
- Implement `get`/`set_bmc_configuration` so `nodebmcconfiguration` can read and set all iDRAC variables: attribute resources (iDRAC/System/LifecycleController scopes) are located via the manager's `Links.Oem.Dell.DellAttributes` (fallback to `<manager>/Attributes` for older firmware), merged on read, and each change routed back to the owning resource with integer coercion based on current value types.

Management of discovered nodes then flows through the existing redfish plugin and the existing Dell OEM handler selection via the service root Vendor field.

Tested by compile/lint only; I don't have Dell hardware on the bench right now, so testing on a real iDRAC9 would be appreciated before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)