### PR TITLE
Improve SEL record type handling in aiohmi

### DIFF
--- a/confluent_server/aiohmi/ipmi/events.py
+++ b/confluent_server/aiohmi/ipmi/events.py
@@ -519,12 +519,25 @@ class EventHandler(object):
         selentry = bytearray(origselentry)
         event = {}
         event['record_id'] = struct.unpack_from('<H', origselentry[:2])[0]
-        if selentry[2] == 2 or (0xc0 <= selentry[2] <= 0xdf):
+        if selentry[2] < 0xe0 and len(selentry) >= 7:
             # Either standard, or at least the timestamp is standard
             event['timecode'] = struct.unpack_from('<I', buffer(selentry[3:7])
                                                    )[0]
-        if selentry[2] == 2:  # ipmi defined standard format
-            self._decode_standard_event(selentry[7:], event)
+        if selentry[2] < 0xc0:
+            # ipmi defined standard format (0x02); like ipmitool, extend the
+            # same treatment to reserved types some BMCs use (e.g. AMI 0x04)
+            try:
+                self._decode_standard_event(selentry[7:], event)
+            except Exception:
+                if selentry[2] == 2:
+                    raise
+                # a reserved type that does not actually follow the standard
+                # layout; discard any partially decoded fields and pass it
+                # through raw rather than aborting the fetch
+                for key in list(event):
+                    if key not in ('record_id', 'timecode'):
+                        del event[key]
+                event['oemdata'] = selentry[3:]
         elif 0xc0 <= selentry[2] <= 0xdf:
             event['oemid'] = selentry[7:10]
             event['oemdata'] = selentry[10:]

--- a/confluent_server/aiohmi/ipmi/events.py
+++ b/confluent_server/aiohmi/ipmi/events.py
@@ -529,9 +529,7 @@ class EventHandler(object):
             try:
                 self._decode_standard_event(selentry[7:], event)
             except Exception:
-                if selentry[2] == 2:
-                    raise
-                # a reserved type that does not actually follow the standard
+                # a record body that does not actually follow the standard
                 # layout; discard any partially decoded fields and pass it
                 # through raw rather than aborting the fetch
                 for key in list(event):

--- a/confluent_server/aiohmi/ipmi/events.py
+++ b/confluent_server/aiohmi/ipmi/events.py
@@ -541,6 +541,18 @@ class EventHandler(object):
         elif 0xc0 <= selentry[2] <= 0xdf:
             event['oemid'] = selentry[7:10]
             event['oemdata'] = selentry[10:]
+        elif selentry[2] == 0xf0:
+            # De facto standard from the Linux kernel ipmi panic logger,
+            # also recognized by ipmitool and freeipmi: byte 4 is a chunk
+            # sequence number and bytes 5-15 carry a piece of the panic
+            # string
+            event['event'] = 'Linux kernel panic: {0}'.format(
+                selentry[5:16].partition(b'\x00')[0].decode(
+                    'utf-8', 'replace'))
+            event['severity'] = pygconst.Health.Critical
+            # this layout is defined by the kernel convention rather than
+            # the BMC vendor, so bypass the OEM handler
+            return event
         elif selentry[2] >= 0xe0:
             # In this class of OEM message, all bytes are OEM, interpretation
             # is wholly left up to the OEM layer, using the OEM ID of the BMC

--- a/confluent_server/aiohmi/ipmi/oem/generic.py
+++ b/confluent_server/aiohmi/ipmi/oem/generic.py
@@ -143,7 +143,9 @@ class OEMHandler(object):
         to apply some transform to some field to suit their conventions.
         """
         event['oem_handler'] = None
-        evdata = event['event_data_bytes']
+        evdata = event.get('event_data_bytes')
+        if evdata is None:
+            return
         if evdata[0] & 0b11000000 == 0b10000000:
             event['oem_byte2'] = evdata[1]
         if evdata[0] & 0b110000 == 0b100000:


### PR DESCRIPTION
_Note: Comparison and testing was AI assisted._

## Improve SEL record type handling in aiohmi

Fetching the event log died with an unhandled exception as soon as one SEL entry was not a well-formed type 0x02 system event record. A single OEM record, or a spec-reserved type as logged by some BMCs (AMI uses 0x04, for example), aborted the whole `nodeeventlog`. ipmitool and freeipmi both handle these records; this PR brings aiohmi to parity.

- **Fix crash if sel entry is not OEM**: the generic OEM handler dereferenced `event['event_data_bytes']` unconditionally, crashing on any record without a standard decode.
- **Decode reserved SEL record types as standard events**: treat all types < 0xC0 as standard format like ipmitool does; if the body turns out not to follow the standard layout (or is truncated), fall back to passing the record through raw instead of aborting.
- **Decode Linux kernel panic SEL records**: type 0xF0 is the de facto convention used by the Linux kernel ipmi panic logger (chunk sequence in byte 4, up to 11 chars of panic string in bytes 5-15), recognized by ipmitool and freeipmi.
- **Tolerate standard SEL records with malformed bodies**: a corrupt 0x02 record also degrades to the raw passthrough now.

**Note:** with the last commit aiohmi becomes deliberately *more* tolerant than before for 0x02 records: a genuinely corrupt standard record is passed through as raw data rather than surfacing an error. This is the same trade-off ipmitool makes, since one bad entry must never block retrieval of the rest of the log. With all the various (broken) BMCs out there I think it's still better to continue than crash. 

### Record type classification: spec vs. implementations

Spec: [IPMI v2.0, section 32, Tables 32-1 to 32-3](https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/ipmi-intelligent-platform-mgt-interface-spec-2nd-gen-v2-0-spec-update.pdf)

| Record type | IPMI spec meaning | ipmitool | freeipmi | aiohmi (before) | aiohmi (this PR) |
|---|---|---|---|---|---|
| 0x00-0x01, 0x03-0xBF | Reserved | [Standard](https://github.com/ipmitool/ipmitool/blob/be11d948f89b10be094e28d8a0a5e8fb532c7b60/lib/ipmi_sel.c#L1701) | [Unknown, parse error](https://github.com/chu11/freeipmi-mirror/blob/ceabef84bea3d0c59655c576ba61e3451daffa08/libfreeipmi/sel/ipmi-sel.c#L2254) ([Standard with `--assume-system-event-records`](https://github.com/chu11/freeipmi-mirror/blob/ceabef84bea3d0c59655c576ba61e3451daffa08/libfreeipmi/sel/ipmi-sel-common.c#L180-L182)) | [Undecoded, raw entry to vendor OEM hook](https://github.com/xcat2/confluent/blob/0272137e94392afc327843f69edc533f2968250e/confluent_server/aiohmi/ipmi/events.py#L522-L526) | [Standard, raw fallback if body is not standard layout](https://github.com/Obihoernchen/confluent/blob/ipmioemfix/confluent_server/aiohmi/ipmi/events.py#L526) |
| 0x02 | System event record | [Standard](https://github.com/ipmitool/ipmitool/blob/be11d948f89b10be094e28d8a0a5e8fb532c7b60/lib/ipmi_sel.c#L1701) | [Standard](https://github.com/chu11/freeipmi-mirror/blob/ceabef84bea3d0c59655c576ba61e3451daffa08/libfreeipmi/include/freeipmi/record-format/ipmi-sel-record-format.h#L39-L40) | [Standard, crash on malformed body](https://github.com/xcat2/confluent/blob/0272137e94392afc327843f69edc533f2968250e/confluent_server/aiohmi/ipmi/events.py#L526) | [Standard, raw fallback on malformed body](https://github.com/Obihoernchen/confluent/blob/ipmioemfix/confluent_server/aiohmi/ipmi/events.py#L529-L538) |
| 0xC0-0xDF | Timestamped OEM | [Timestamped OEM](https://github.com/ipmitool/ipmitool/blob/be11d948f89b10be094e28d8a0a5e8fb532c7b60/lib/ipmi_sel.c#L1715) | [Timestamped OEM](https://github.com/chu11/freeipmi-mirror/blob/ceabef84bea3d0c59655c576ba61e3451daffa08/libfreeipmi/include/freeipmi/record-format/ipmi-sel-record-format.h#L42-L44) | [Timestamped OEM, KeyError in generic OEM handler](https://github.com/xcat2/confluent/blob/0272137e94392afc327843f69edc533f2968250e/confluent_server/aiohmi/ipmi/events.py#L528) | [Timestamped OEM](https://github.com/Obihoernchen/confluent/blob/ipmioemfix/confluent_server/aiohmi/ipmi/events.py#L539) |
| 0xE0-0xFF | Non-timestamped OEM | [Non-timestamped OEM](https://github.com/ipmitool/ipmitool/blob/be11d948f89b10be094e28d8a0a5e8fb532c7b60/lib/ipmi_sel.c#L1725) ([0xF0 = Linux kernel panic](https://github.com/ipmitool/ipmitool/blob/be11d948f89b10be094e28d8a0a5e8fb532c7b60/lib/ipmi_sel.c#L1788)) | [Non-timestamped OEM](https://github.com/chu11/freeipmi-mirror/blob/ceabef84bea3d0c59655c576ba61e3451daffa08/libfreeipmi/include/freeipmi/record-format/ipmi-sel-record-format.h#L47-L49) ([0xF0 panic with OEM interpretation](https://github.com/chu11/freeipmi-mirror/blob/ceabef84bea3d0c59655c576ba61e3451daffa08/libfreeipmi/sel/ipmi-sel-string-linux-kernel.c)) | [Non-timestamped OEM, KeyError in generic OEM handler](https://github.com/xcat2/confluent/blob/0272137e94392afc327843f69edc533f2968250e/confluent_server/aiohmi/ipmi/events.py#L531) | [Non-timestamped OEM](https://github.com/Obihoernchen/confluent/blob/ipmioemfix/confluent_server/aiohmi/ipmi/events.py#L554) ([0xF0 = Linux kernel panic](https://github.com/Obihoernchen/confluent/blob/ipmioemfix/confluent_server/aiohmi/ipmi/events.py#L542)) |

### Test results

19 synthetic SEL records (proper and broken data for each record type class, including truncated records) were run through all four parsers; full output in the attached `sel_recordtype_tests.log`. ipmitool: git master built from source, fed via `sel readraw`; freeipmi 1.6.15: libfreeipmi with `ASSUME_SYSTEM_EVENT_RECORDS`; aiohmi: `EventHandler._sel_decode` with the generic OEM handler, which is what any BMC without an IBM/Lenovo manufacturer ID gets. The Lenovo vendor handler checks for `oemdata` first and tolerates OEM records even before this PR; the last row exercises that path. **CRASH** means the exception aborts the entire SEL retrieval.

| Case | ipmitool | freeipmi (assume-flag) | aiohmi (before) | aiohmi (this PR) |
|---|---|---|---|---|
| 0x02 proper | decoded | decoded | decoded | decoded |
| 0x02 broken body | prints, empty description | prints raw offsets | **CRASH** | raw fallback |
| Reserved (0x00/0x04/0x30), standard layout | decoded | decoded | **CRASH** | decoded |
| Reserved, broken body | prints garbage row | prints raw offsets | **CRASH** | raw fallback |
| 0xC0/0xDF OEM proper and broken | mfg + hex | mfg + hex | **CRASH** | mfg + hex |
| 0xE0/0xFF OEM proper and broken | hex dump | hex dump | **CRASH** | hex dump |
| 0xF0 panic string | "Linux kernel panic: Oops: 0002" | raw hex (needs live-BMC OEM context) | **CRASH** | "Linux kernel panic: Oops: 0002", severity Critical |
| 0xF0 garbage string | prints mojibake | raw hex | **CRASH** | decoded with replacement chars |
| Truncated (13 / 5 bytes) | n/a (16-byte file framing) | rejected with error | **CRASH** | raw fallback |
| Lenovo 0xD0 firmware update, Lenovo vendor handler | mfg + hex | mfg + hex | decoded ("UEFI/BIOS Update succeeded 3.47") | decoded (same) |

[sel_recordtype_tests.log](https://github.com/user-attachments/files/29894288/sel_recordtype_tests.log)
