### PR TITLE
Fix Shellcheck errors

### DIFF
--- a/confluent_client/confluent_env.sh
+++ b/confluent_client/confluent_env.sh
@@ -53,6 +53,8 @@ _confluent_get_args()
         CMPARGS+=("")
     fi
     GENNED=""
+    # Whitespace separates candidate groups, while commas group synonyms.
+    # shellcheck disable=SC2068
     for CAND in ${COMP_CANDIDATES[@]}; do
         candarray=(${CAND//,/ })
         matched=0

--- a/confluent_osdeploy/debian/profiles/default/scripts/pre.sh
+++ b/confluent_osdeploy/debian/profiles/default/scripts/pre.sh
@@ -34,8 +34,8 @@ done
 if [ -e /tmp/installdisk ]; then
     instdisk=$(cat /tmp/installdisk)
 else
-    for blockdev in $(ls /sys/class/block/); do
-        shortname=$(basename $blockdev)
+    for blockdev in /sys/class/block/*; do
+        shortname=$(basename "$blockdev")
         if [ "$shortname" != "${shortname%loop*}" ]; then
             continue
         fi
@@ -62,7 +62,7 @@ else
     done
 fi
 if [ -z "$instdisk" ]; then
-    if [ ! -z "$sraid"]; then
+    if [ ! -z "$sraid" ]; then
         instdisk=$sraid
     elif [ ! -z "$onbdisk" ]; then
         instdisk=$onbdisk

--- a/confluent_osdeploy/ubuntu18.04/profiles/default/scripts/pre.sh
+++ b/confluent_osdeploy/ubuntu18.04/profiles/default/scripts/pre.sh
@@ -34,8 +34,8 @@ done
 if [ -e /tmp/installdisk ]; then
     instdisk=$(cat /tmp/installdisk)
 else
-    for blockdev in $(ls /sys/class/block/); do
-        shortname=$(basename $blockdev)
+    for blockdev in /sys/class/block/*; do
+        shortname=$(basename "$blockdev")
         if [ "$shortname" != "${shortname%loop*}" ]; then
             continue
         fi
@@ -62,7 +62,7 @@ else
     done
 fi
 if [ -z "$instdisk" ]; then
-    if [ ! -z "$sraid"]; then
+    if [ ! -z "$sraid" ]; then
         instdisk=$sraid
     elif [ ! -z "$onbdisk" ]; then
         instdisk=$onbdisk


### PR DESCRIPTION
Fix SC2045 (error): Iterating over ls output is fragile. Use globs.

Add exception SC2068 exception for confluent_client/confluent_env.sh as this is intended. SC2068 (error): Double quote array expansions to avoid re-splitting elements.