### PR TITLE
Preserve scoped IPv6 console addresses

### DIFF
--- a/confluent_server/confluent/plugins/console/openbmc.py
+++ b/confluent_server/confluent/plugins/console/openbmc.py
@@ -22,11 +22,9 @@
 import asyncio
 import confluent.exceptions as cexc
 import confluent.interface.console as conapi
-import confluent.log as log
 import confluent.tasks as tasks
 import confluent.util as util
 import aiohmi.exceptions as pygexc
-import aiohmi.redfish.command as rcmd
 import aiohmi.util.webclient as webclient
 import aiohttp
 
@@ -79,7 +77,7 @@ class OpenBmcConsole(conapi.Console):
         self.password = connparams['passphrase']
         self.bmc = connparams['bmc']
         self.origbmc = connparams['bmc']
-        if ':' in self.bmc:
+        if ':' in self.bmc and not self.bmc.startswith('['):
             self.bmc = '[{0}]'.format(self.bmc)
         self.datacallback = None
         self.nodeconfig = config
@@ -114,10 +112,6 @@ class OpenBmcConsole(conapi.Console):
             raise cexc.TargetEndpointUnreachable(str(e))
         if rsp[1] > 400:
             raise cexc.TargetEndpointBadCredentials
-        bmc = self.bmc
-        if '%' in self.bmc:
-            prefix = self.bmc.split('%')[0]
-            bmc = prefix + ']'
         self.ssl = CustomVerifier(kv)
         self.clisess = aiohttp.ClientSession(cookie_jar=wc.cookies)
         protos = []

--- a/confluent_server/confluent/plugins/console/tsmsol.py
+++ b/confluent_server/confluent/plugins/console/tsmsol.py
@@ -22,7 +22,6 @@
 import asyncio
 import confluent.exceptions as cexc
 import confluent.interface.console as conapi
-import confluent.log as log
 import confluent.tasks as tasks
 import confluent.util as util
 import aiohmi.exceptions as pygexc
@@ -79,7 +78,7 @@ class TsmConsole(conapi.Console):
         self.password = connparams['passphrase']
         self.bmc = connparams['bmc']
         self.origbmc = connparams['bmc']
-        if ':' in self.bmc:
+        if ':' in self.bmc and not self.bmc.startswith('['):
             self.bmc = '[{0}]'.format(self.bmc)
         self.datacallback = None
         self.nodeconfig = config
@@ -117,10 +116,6 @@ class TsmConsole(conapi.Console):
             await rc.await_redirect()
         except Exception as e:
             raise cexc.TargetEndpointUnreachable(str(e))
-        bmc = self.bmc
-        if '%' in self.bmc:
-            prefix = self.bmc.split('%')[0]
-            bmc = prefix + ']'
         self.ssl = CustomVerifier(kv)
         self.clisess = aiohttp.ClientSession(cookie_jar=rc.oem.wc.cookies)
         self.ws = await self.clisess.ws_connect(

--- a/confluent_server/confluent/plugins/hardwaremanagement/proxmox.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/proxmox.py
@@ -115,10 +115,8 @@ class PmxConsole(conapi.Console):
         self.datacallback = callback
         kv = util.TLSCertVerifier(
             self.nodeconfig, self.node, 'pubkeys.tls_hardwaremanager').verify_cert
-        bmc = self.bmc
-        if '%' in self.bmc:
-            prefix = self.bmc.split('%')[0]
-            bmc = prefix + ']'
+        if ':' in self.bmc and not self.bmc.startswith('['):
+            self.bmc = '[{0}]'.format(self.bmc)
         self.ssl = CustomVerifier(kv)
         ticket = self.consdata['ticket']
         user = self.consdata['user']
@@ -486,7 +484,6 @@ async def create(nodes, element, configmanager, inputdata):
 if __name__ == '__main__':
     import sys
     import os
-    from pprint import pprint
     myuser = os.environ['PMXUSER']
     mypass = os.environ['PMXPASS']
     vc = PmxApiClient(sys.argv[1], myuser, mypass, None)


### PR DESCRIPTION
Before the async port the bmc var was used for a "host=bmc" parameter which does not exist anymore.

Now add `[]` around IPv6 addresses with missing brackets but keep the scope zone like `%eth0` as this is needed in current code.