### PR TITLE
ruff auto fixes

### DIFF
--- a/confluent_client/confluent/asynclient.py
+++ b/confluent_client/confluent/asynclient.py
@@ -762,7 +762,7 @@ async def updateattrib(session, updateargs, nodetype, noderange, options, dictas
         if "=" in updateargs[1]:
             update_ready = True
             for arg in updateargs[1:]:
-                if not '=' in arg:
+                if '=' not in arg:
                     update_ready = False
                     exitcode = 1
             if not update_ready:

--- a/confluent_client/confluent/client.py
+++ b/confluent_client/confluent/client.py
@@ -712,7 +712,7 @@ def updateattrib(session, updateargs, nodetype, noderange, options, dictassign=N
         if "=" in updateargs[1]:
             update_ready = True
             for arg in updateargs[1:]:
-                if not '=' in arg:
+                if '=' not in arg:
                     update_ready = False
                     exitcode = 1
             if not update_ready:

--- a/confluent_client/confluent/textgroup.py
+++ b/confluent_client/confluent/textgroup.py
@@ -138,8 +138,6 @@ class GroupedData(object):
     def print_all(self, output=sys.stdout, skipmodal=False, reverse=False,
                   count=False):
         self.generate_byoutput()
-        modaloutput = None
-        ismodal = True
 
         if reverse:
             outdatalist = sorted(

--- a/confluent_client/confluent/vnc.py
+++ b/confluent_client/confluent/vnc.py
@@ -215,7 +215,7 @@ class VNCClient:
         self._request_screen_update(incremental=True)
 
     async def _handle_rectangle(self):
-        if self.framebuffer == None:
+        if self.framebuffer is None:
             self.framebuffer = Image.new('RGBA', (self.width, self.height))
         x = await self._read_number(2)
         y = await self._read_number(2)

--- a/confluent_osdeploy/ubuntu20.04-diskless/profiles/default/scripts/image2disk.py
+++ b/confluent_osdeploy/ubuntu20.04-diskless/profiles/default/scripts/image2disk.py
@@ -431,4 +431,3 @@ if __name__ == '__main__':
         traceback.print_exc()
         time.sleep(86400)
         raise
-

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -345,7 +345,7 @@ class Command(object):
             return {'powerstate': oldpowerstate}
         if newpowerstate == 'boot':
             newpowerstate = 'on' if oldpowerstate == 'off' else 'reset'
-        response = await self.raw_command(
+        await self.raw_command(
             netfn=0, command=2, data=[power_states[newpowerstate]],
             bridge_request=bridge_request)
         lastresponse = {'pendingpowerstate': newpowerstate}
@@ -564,7 +564,7 @@ class Command(object):
                 duration = 255
             if duration < 0:
                 duration = 0
-            response = await self.raw_command(netfn=0, command=4, data=[duration])
+            await self.raw_command(netfn=0, command=4, data=[duration])
             return
         forceon = 0
         if on:
@@ -575,7 +575,7 @@ class Command(object):
             identifydata = [255 * forceon]
         else:
             identifydata = [0, forceon]
-        response = await self.raw_command(netfn=0, command=4, data=identifydata)
+        await self.raw_command(netfn=0, command=4, data=identifydata)
 
     async def init_sdr(self):
         """Initialize SDR
@@ -891,7 +891,6 @@ class Command(object):
         if channel is None:
             channel = await self.get_network_channel()
         if static_addresses is not None:
-            i = 0
             for va in static_addresses:
                 if '/' in va:
                     va, plen = va.split('/', 1)
@@ -2238,7 +2237,8 @@ class Command(object):
 
         await self.oem_init()
         if progress is None:
-            progress = lambda x: True
+            def progress(x):
+                return True
         return await self._oem.update_firmware(filename, data, progress, bank)
 
     async def attach_remote_media(self, url, username=None, password=None):

--- a/confluent_server/aiohmi/ipmi/oem/generic.py
+++ b/confluent_server/aiohmi/ipmi/oem/generic.py
@@ -67,7 +67,6 @@ class OEMHandler(object):
         # in practice, some implementations use 0x27 ('External environment')
         if not hasattr(self, '_processor_names'):
             self._processor_names = []
-        readings = []
         if not self._processor_names:
             sdr = await ipmicmd.init_sdr()
             for sensename in sdr.sensors:

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/config.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/config.py
@@ -23,7 +23,6 @@ import base64
 import random
 import struct
 
-import time
 
 import aiohmi.exceptions as pygexc
 

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
@@ -17,7 +17,6 @@ import asyncio
 import base64
 import binascii
 from datetime import datetime
-import errno
 import fnmatch
 import json
 import math
@@ -28,7 +27,6 @@ import socket
 import struct
 import weakref
 
-import six
 import zipfile
 
 import aiohmi.constants as pygconst
@@ -848,7 +846,7 @@ class IMMClient(object):
         # https, using the caller TLS verification scheme
         components = set(components)
         if 'core' in components:
-            category = 'core'        
+            category = 'core'
         if not components or set(('imm', 'xcc', 'bmc', 'core')) & components:
             rsp = await self.ipmicmd.raw_command(netfn=0x3a, command=0x50)
             immverdata = self.parse_imm_buildinfo(rsp['data'])

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -21,7 +21,6 @@ import hmac
 import operator
 import os
 import random
-import select
 import socket
 import struct
 #import threading
@@ -34,7 +33,6 @@ from cryptography.hazmat.primitives.ciphers import modes
 
 import aiohmi.exceptions as exc
 from aiohmi.ipmi.private import constants
-from aiohmi.ipmi.private import util
 from aiohmi.ipmi.private.util import _monotonic_time
 from aiohmi.ipmi.private.util import get_ipmi_error
 
@@ -1578,7 +1576,7 @@ class Session(object):
             payload=payload, payload_type=constants.payload_types['rakp1'])
 
     async def _got_rakp2(self, data):
-        if not (self.sessioncontext in ('EXPECTINGRAKP2', 'EXPECTINGRAKP4')):
+        if self.sessioncontext not in ('EXPECTINGRAKP2', 'EXPECTINGRAKP4'):
             # if we are not expecting rakp2, ignore. In a retry
             # scenario, replying from stale RAKP2 after sending
             # RAKP3 seems to be best

--- a/confluent_server/aiohmi/ipmi/private/simplesession.py
+++ b/confluent_server/aiohmi/ipmi/private/simplesession.py
@@ -1087,7 +1087,7 @@ class Session(object):
             payload=payload, payload_type=constants.payload_types['rakp1'])
 
     def _got_rakp2(self, data):
-        if not (self.sessioncontext in ('EXPECTINGRAKP2', 'EXPECTINGRAKP4')):
+        if self.sessioncontext not in ('EXPECTINGRAKP2', 'EXPECTINGRAKP4'):
             # if we are not expecting rakp2, ignore. In a retry
             # scenario, replying from stale RAKP2 after sending
             # RAKP3 seems to be best

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -19,18 +19,13 @@ for redfish compliant endpoints
 """
 
 import asyncio
-import base64
-from datetime import datetime
-from datetime import timedelta
 import json
 import os
 import re
 import socket
 import struct
 import sys
-import time
 
-from dateutil import tz
 
 import aiohmi.constants as const
 import aiohmi.exceptions as exc
@@ -1551,7 +1546,8 @@ class Command(object):
          :param bank: Indicate a target 'bank' of firmware if supported
         """
         if progress is None:
-            progress = lambda x: True
+            def progress(x):
+                return True
         oem = await self.oem()
         return await oem.update_firmware(file, data, progress, bank, otherfields)
 

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -17,7 +17,6 @@ from fnmatch import fnmatch
 import json
 import os
 import re
-import time
 import uuid
 
 import base64
@@ -1431,7 +1430,6 @@ class OEMHandler(object):
             uploadthread = await webclient.make_uploader(
                 self.webclient, upurl, filename, data, formname='UpdateFile', formwrap=ismultipart,
                 otherfields=otherfields)
-            wc = self.webclient
             while not uploadthread.completed():
                 try:
                     await uploadthread.join(3)

--- a/confluent_server/aiohmi/redfish/oem/lenovo/smm3.py
+++ b/confluent_server/aiohmi/redfish/oem/lenovo/smm3.py
@@ -20,7 +20,6 @@ import aiohmi.constants as pygconst
 import aiohmi.util.webclient as webclient
 import aiohmi.exceptions as exc
 import time
-import socket
 
 healthlookup = {
     'ok': pygconst.Health.Ok,
@@ -283,7 +282,7 @@ class OEMHandler(generic.OEMHandler):
     async def reseat_bay(self, bay):
         bayid = _baytolabel(bay)
         url = '/redfish/v1/Chassis/chassis1/Oem/Lenovo/Nodes/{}/Actions/Node.Reseat'.format(bayid)
-        rsp = await self._do_web_request(url, method='POST')
+        await self._do_web_request(url, method='POST')
 
     async def get_event_log(self, clear=False, fishclient=None):
         return await super().get_event_log(clear, fishclient, extraurls=[{'@odata.id':'/redfish/v1/Chassis/chassis1/LogServices/EventLog'}])

--- a/confluent_server/aiohmi/redfish/oem/lenovo/tsma.py
+++ b/confluent_server/aiohmi/redfish/oem/lenovo/tsma.py
@@ -15,7 +15,6 @@
 import asyncio
 import os
 import struct
-import time
 try:
     from urllib import urlencode
 except ImportError:

--- a/confluent_server/aiohmi/redfish/oem/lenovo/xcc.py
+++ b/confluent_server/aiohmi/redfish/oem/lenovo/xcc.py
@@ -14,7 +14,6 @@
 
 
 import asyncio
-import errno
 import fnmatch
 import json
 import math
@@ -22,7 +21,6 @@ import os
 import random
 import re
 import socket
-import time
 
 import zipfile
 
@@ -564,7 +562,6 @@ class OEMHandler(generic.OEMHandler):
             'E': pygconst.Health.Critical,
             'W': pygconst.Health.Warning,
         }
-        infoevents = False
         existingevts = set([])
         for item in rsp.get('items', ()):
             # while usually the ipmi interrogation shall explain things,
@@ -573,7 +570,6 @@ class OEMHandler(generic.OEMHandler):
             itemseverity = hmap.get(item.get('severity', 'E'),
                                     pygconst.Health.Critical)
             if itemseverity == pygconst.Health.Ok:
-                infoevents = True
                 continue
             if (summary['health'] < itemseverity):
                 summary['health'] = itemseverity
@@ -1342,7 +1338,6 @@ class OEMHandler(generic.OEMHandler):
                          '/FirmwareInventory/BMC-Backup']}, method='PATCH')
             uploadtask = await webclient.make_uploader(
                 self.webclient, upurl, filename, data, formwrap=False)
-            wc = self.webclient
             while not uploadtask.completed():
                 try:
                     await uploadtask.join(3)

--- a/confluent_server/aiohmi/redfish/oem/lenovo/xcc3.py
+++ b/confluent_server/aiohmi/redfish/oem/lenovo/xcc3.py
@@ -127,7 +127,6 @@ class OEMHandler(generic.OEMHandler):
         if adapterdata:
             anames = {}
             for adata, _ in adapterdata:
-                skipadapter = False
                 clabel = adata['Slot']['Location']['PartLocation'].get('LocationType','')
                 if not clabel:
                     clabel = adata['Slot']['Location']['PartLocation'].get('ServiceLabel', '').split("=")[0]                
@@ -831,7 +830,6 @@ class OEMHandler(generic.OEMHandler):
             3: pygconst.Health.Critical,
             2: pygconst.Health.Warning,
         }
-        infoevents = False
         existingevts = set([])
         for item in rsp.get('items', ()):
             # while usually the ipmi interrogation shall explain things,
@@ -840,7 +838,6 @@ class OEMHandler(generic.OEMHandler):
             itemseverity = hmap.get(item.get('Severity', 2),
                                     pygconst.Health.Critical)
             if itemseverity == pygconst.Health.Ok:
-                infoevents = True
                 continue
             if (summary['health'] < itemseverity):
                 summary['health'] = itemseverity
@@ -1113,7 +1110,6 @@ class OEMHandler(generic.OEMHandler):
                 extrainfo, valtodisplay, _, _ = reginfo
         for setting in bmcstgs.get('Attributes', {}):
             val = bmcstgs['Attributes'][setting]
-            currval = val
             val = valtodisplay.get(setting, {}).get(val, val)
             val = {'value': val}
             val.update(**extrainfo.get(setting, {}))

--- a/confluent_server/aiohmi/util/webclient.py
+++ b/confluent_server/aiohmi/util/webclient.py
@@ -18,15 +18,9 @@
 
 import asyncio
 import base64
-import copy
-import gzip
 import io
 import json
 import os
-import socket
-import ssl
-import threading
-import traceback
 
 from yarl import URL
 import aiohmi.exceptions as pygexc
@@ -35,8 +29,6 @@ import aiohmi.exceptions as pygexc
 import aiohttp
 from aiohttp.cookiejar import CookieJar
 
-import http.client as httplib
-import http.cookies as Cookie
 
 # Used as the separator for form data
 
@@ -334,7 +326,7 @@ class WebConnection:
                 kwargs['json'] = body
             elif body:
                 kwargs['data'] = body
-            async with thefunc(url, headers=headers, ssl=self.ssl, **kwargs) as rsp:
+            async with thefunc(url, headers=headers, ssl=self.ssl, **kwargs):
                 pass
 
     def set_basic_credentials(self, username, password):

--- a/confluent_server/confluent/asynchttp.py
+++ b/confluent_server/confluent/asynchttp.py
@@ -29,13 +29,11 @@
 # far away.
 
 import asyncio
-import collections
 import confluent.exceptions as exc
 import confluent.messages as messages
 import confluent.util as util
 import confluent.core as core
 import confluent.log as log
-import time
 
 _asyncsessions = {}
 _consolesessions = None

--- a/confluent_server/confluent/auth.py
+++ b/confluent_server/confluent/auth.py
@@ -27,9 +27,7 @@ import confluent.config.configmanager as configmanager
 from concurrent.futures import ProcessPoolExecutor
 from fnmatch import fnmatch
 import hashlib
-import hmac
 import msgpack
-import multiprocessing
 import os
 import pwd
 import confluent.tasks as tasks
@@ -40,7 +38,6 @@ try:
     import confluent.pam as pam
 except ImportError:
     pass
-import time
 import yaml
 
 _pamservice = 'confluent'

--- a/confluent_server/confluent/certutil.py
+++ b/confluent_server/confluent/certutil.py
@@ -154,7 +154,7 @@ def get_certificate_paths():
     return tlsmateriallocation
 
 async def assure_tls_ca():
-    keyout, certout = ('/etc/confluent/tls/cakey.pem', '/etc/confluent/tls/cacert.pem')
+    _keyout, certout = ('/etc/confluent/tls/cakey.pem', '/etc/confluent/tls/cacert.pem')
     if not os.path.exists(certout):
         #create_simple_ca(keyout, certout)
         await create_full_ca(certout)

--- a/confluent_server/confluent/collective/manager.py
+++ b/confluent_server/confluent/collective/manager.py
@@ -31,7 +31,6 @@ import ctypes
 import ctypes.util
 import random
 import time
-import sys
 
 
 class PyObject_HEAD(ctypes.Structure):
@@ -86,7 +85,6 @@ async def connect_to_leader(cert=None, name=None, leader=None, remote=None, isre
     ocert = cert
     oname = name
     oleader = leader
-    oremote = remote
     if leader is None:
         leader = currentleader
     if not isretry:
@@ -128,7 +126,7 @@ async def connect_to_leader(cert=None, name=None, leader=None, remote=None, isre
                     await asyncio.sleep(0.3)
                     return await connect_to_leader(cert, name, leader, None, isretry=True)
                 if 'leader' in keydata:
-                    if keydata['leader'] == None:
+                    if keydata['leader'] is None:
                         return None
                     log.log(
                         {'info': 'Prospective leader {0} has redirected this '
@@ -144,8 +142,7 @@ async def connect_to_leader(cert=None, name=None, leader=None, remote=None, isre
                     log.log({'info':
                                  'Prospective leader {0} has inferior '
                                  'transaction count, becoming leader'
-                                 ''.format(leader), 'subsystem': 'collective',
-                             'subsystem': 'collective'})
+                                 ''.format(leader), 'subsystem': 'collective'})
                     return await become_leader(remote)
                 return False
                 follower.cancel()
@@ -815,7 +812,7 @@ async def reassimilate_missing():
     while True:
         try:
             await _assimilate_missing()
-        except Exception as e:
+        except Exception:
             cfm.logException()
         await asyncio.sleep(30)
 
@@ -960,7 +957,7 @@ async def start_collective():
                 else:
                     remote[1].close()
                     await remote[1].wait_closed()
-    except Exception as e:
+    except Exception:
         pass
     finally:
         if retrythread is None and follower is None:

--- a/confluent_server/confluent/config/configmanager.py
+++ b/confluent_server/confluent/config/configmanager.py
@@ -621,7 +621,7 @@ def _load_dict_from_dbm(dpath, tdb):
                 currdict[tks] = cPickle.loads(dbe[tk]) # nosec
         except AttributeError:
             tk = dbe.firstkey()
-            while tk != None:
+            while tk is not None:
                 tks = confluent.util.stringify(tk)
                 currdict[tks] = cPickle.loads(dbe[tk]) # nosec
                 tk = dbe.nextkey(tk)
@@ -931,7 +931,7 @@ def commit_clear():
         for cfg in todelete:
             try:
                 os.remove(os.path.join(ConfigManager._cfgdir, cfg))
-            except OSError as oe:
+            except OSError:
                 pass
     ConfigManager.wait_for_sync(True)
     ConfigManager._bg_sync_to_file()
@@ -1950,7 +1950,7 @@ class ConfigManager(object):
         # if the attribute is not set, this will search for a candidate
         # if it is set, but inheritedfrom, search for a replacement, just
         # in case
-        if not 'groups' in nodecfg:
+        if 'groups' not in nodecfg:
             return
         for group in nodecfg['groups']:
             if attrib in self._cfgstore['nodegroups'][group]:
@@ -2041,7 +2041,7 @@ class ConfigManager(object):
                 try:
                     noderange._parser.parseString(
                         '({0})'.format(group)).asList()
-                except noderange.pp.ParseException as pe:
+                except noderange.pp.ParseException:
                     raise ValueError('"{0}" is not a valid group name'.format(
                         group))
             if not autocreate and group not in self._cfgstore['nodegroups']:
@@ -2531,7 +2531,7 @@ class ConfigManager(object):
                 try:
                     noderange._parser.parseString(
                         '({0})'.format(node)).asList()
-                except noderange.pp.ParseException as pe:
+                except noderange.pp.ParseException:
                     raise ValueError(
                         '"{0}" is not a valid node name'.format(node))
             if autocreate is False and node not in self._cfgstore['nodes']:
@@ -2700,7 +2700,7 @@ class ConfigManager(object):
                 try:
                     noderange._parser.parseString(
                         '({0})'.format(element)).asList()
-                except noderange.pp.ParseException as pe:
+                except noderange.pp.ParseException:
                     raise ValueError(
                         '"{0}" is not a supported name, it must be renamed or '
                         'removed from backup to restore'.format(element))

--- a/confluent_server/confluent/consoleserver.py
+++ b/confluent_server/confluent/consoleserver.py
@@ -401,7 +401,7 @@ class ConsoleHandler(object):
             if not self.reconnect:
                 self.reconnect = tasks.spawn_task_after(retrytime, self._connect)
             return
-        except (exc.TargetEndpointUnreachable, socket.gaierror) as se:
+        except (exc.TargetEndpointUnreachable, socket.gaierror):
             await self.clearbuffer()
             self.error = 'unreachable'
             self.connectstate = 'unconnected'
@@ -720,7 +720,7 @@ class ProxyConsole(object):
         }
         try:
             remote = await collective.connect_to_collective(None, self.managerinfo['address'])
-        except Exception as e:
+        except Exception:
             if _tracelog:
                 _tracelog.log(traceback.format_exc(), ltype=log.DataTypes.event, event=log.Events.stacktrace)
             await asyncio.sleep(3)

--- a/confluent_server/confluent/core.py
+++ b/confluent_server/confluent/core.py
@@ -50,7 +50,6 @@ import confluent.networking.macmap as macmap
 import confluent.noderange as noderange
 import confluent.osimage as osimage
 import confluent.plugin as plugin
-import types
 try:
     import confluent.shellmodule as shellmodule
 except ImportError:
@@ -58,7 +57,6 @@ except ImportError:
 import confluent.tasks as tasks
 import confluent.util as util
 import inspect
-import itertools
 import msgpack
 import os
 import struct
@@ -1393,7 +1391,6 @@ class Staging:
             os.remove(stage_file)
             return self.storage_folder + '/{}'.format(filename)
         except FileNotFoundError:
-            file = None
             return False
         
     @staticmethod

--- a/confluent_server/confluent/credserver.py
+++ b/confluent_server/confluent/credserver.py
@@ -73,7 +73,6 @@ class CredServer(object):
                 return
             nodename = util.stringify(await cloop.sock_recv(client, tlv[1]))
             tlv = bytearray(await cloop.sock_recv(client, 2))  # should always be null
-            onlylocal = True
             if tlv[0] == 6:
                 hmacval = await cloop.sock_recv(client, tlv[1])
                 hmackey = self.cfm.get_node_attributes(nodename, ['secret.selfapiarmtoken'], decrypt=True)
@@ -146,7 +145,7 @@ class CredServer(object):
 
 
 async def main():
-    a = CredServer()
+    CredServer()
     while True:
         await asyncio.sleep(86400)
 if __name__ == '__main__':

--- a/confluent_server/confluent/discovery/core.py
+++ b/confluent_server/confluent/discovery/core.py
@@ -791,7 +791,7 @@ def safe_detected(info):
 async def eval_detected(info):
     try:
         await detected(info)
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
     del runningevals[info['hwaddr']]
 
@@ -1255,7 +1255,7 @@ async def eval_node(cfg, handler, info, nodename, manual=False):
         # switch concurrently
         # do some preconfig, for example, to bring a SMM online if applicable
         await handler.preconfig(nodename)
-    except Exception as e:
+    except Exception:
         unknown_info[info['hwaddr']] = info
         info['discostatus'] = 'unidentified'
         errorstr = 'An error occurred during discovery, check the ' \
@@ -1677,7 +1677,7 @@ async def remotescan():
     for remagent in get_subscriptions():
         try:
             await affluent.renotify_me(remagent, mycfm, myname)
-        except Exception as e:
+        except Exception:
             log.log({'error': 'Unexpected problem asking {} for discovery notifications'.format(remagent)})
 
 

--- a/confluent_server/confluent/discovery/handlers/bmc.py
+++ b/confluent_server/confluent/discovery/handlers/bmc.py
@@ -66,7 +66,7 @@ class NodeHandler(generic.NodeHandler):
         try:
             ic = await self._get_ipmicmd()
             passwd = self.DEFAULT_PASS
-        except pygexc.IpmiException as pi:
+        except pygexc.IpmiException:
             havecustomcreds = False
             if user is not None and user != self.DEFAULT_USER:
                 havecustomcreds = True

--- a/confluent_server/confluent/discovery/handlers/cpstorage.py
+++ b/confluent_server/confluent/discovery/handlers/cpstorage.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import confluent.discovery.handlers.bmc as bmchandler
-import confluent.util as util
 try:
     from urllib import urlencode
 except ImportError:
@@ -45,9 +44,9 @@ class NodeHandler(bmchandler.NodeHandler):
                     'privilege': 4,
                 }
                 passchange = urlencode(passchange)
-                rsp = await wc.grab_json_response_with_status('/api/reset-pass',
+                await wc.grab_json_response_with_status('/api/reset-pass',
                                                         passchange)
-                rsp = await wc.grab_json_response_with_status('/api/session',
+                await wc.grab_json_response_with_status('/api/session',
                                                         method='DELETE')
 
     async def config(self, nodename, reset=False):

--- a/confluent_server/confluent/discovery/handlers/eureka.py
+++ b/confluent_server/confluent/discovery/handlers/eureka.py
@@ -21,7 +21,6 @@ sensor readings. It does NOT support IPMI, NIC configuration,
 firmware update, or other BMC-specific operations.
 """
 
-import asyncio
 import confluent.discovery.handlers.generic as generic
 import confluent.util as util
 import aiohmi.util.webclient as webclient
@@ -195,7 +194,6 @@ class NodeHandler(generic.NodeHandler):
             ['secret.hardwaremanagementuser',
              'secret.hardwaremanagementpassword'],
             True)
-        cd = creds.get(nodename, {})
         defuser, defpass = self.get_firmware_default_account_info()
         user, passwd, _ = self.get_node_credentials(
             nodename, creds, defuser, defpass)

--- a/confluent_server/confluent/discovery/handlers/generic.py
+++ b/confluent_server/confluent/discovery/handlers/generic.py
@@ -196,7 +196,7 @@ class NodeHandler(object):
             w.set_basic_credentials(relayuser, relaypass)
             await w.request('GET', self.relay_url)
             r = w.getresponse()
-            rb = r.read()
+            r.read()
             if r.code != 302:
                 raise Exception('Unexpected return from forwarder')
             newurl = r.getheader('Location')

--- a/confluent_server/confluent/discovery/handlers/redfishbmc.py
+++ b/confluent_server/confluent/discovery/handlers/redfishbmc.py
@@ -113,7 +113,7 @@ class NodeHandler(generic.NodeHandler):
                 'AccountTypes': actypes,
                 'Password': self.currpass,
                 }
-            rsp = await wc.grab_json_response_with_status(
+            await wc.grab_json_response_with_status(
                 await self.target_account_url(wc), acctupd, method='PATCH')
 
     async def _get_wc(self):
@@ -124,7 +124,6 @@ class NodeHandler(generic.NodeHandler):
         wc.set_header('Content-Type', 'application/json')
         wc.set_header('Accept', 'application/json')
         wc.set_header('Host', 'credible-bmc')
-        authmode = 0
         if not self.trieddefault:
             rsp, status = await wc.grab_json_response_with_status('/redfish/v1/Managers')
             if status == 403:
@@ -213,7 +212,6 @@ class NodeHandler(generic.NodeHandler):
         return targaccturl
 
     async def config(self, nodename):
-        mgrs = None
         self.nodename = nodename
         creds = self.configmanager.get_node_attributes(
             nodename, ['secret.hardwaremanagementuser',
@@ -231,7 +229,6 @@ class NodeHandler(generic.NodeHandler):
         self.targuser = user
         self.targpass = passwd
         wc = await self._get_wc()
-        curruserinfo = {}
         authupdate = {}
         wc.set_header('Content-Type', 'application/json')
         if user != self.curruser:

--- a/confluent_server/confluent/discovery/handlers/smm3.py
+++ b/confluent_server/confluent/discovery/handlers/smm3.py
@@ -15,7 +15,6 @@
 import asyncio
 
 import confluent.discovery.handlers.redfishbmc as redfishbmc
-import confluent.util as util
 
 
 class NodeHandler(redfishbmc.NodeHandler):

--- a/confluent_server/confluent/discovery/handlers/xcc.py
+++ b/confluent_server/confluent/discovery/handlers/xcc.py
@@ -20,7 +20,6 @@ import confluent.discovery.handlers.xcc3 as xcc3handler
 import confluent.exceptions as exc
 import confluent.netutil as netutil
 import confluent.util as util
-import errno
 import json
 import os
 import aiohmi.exceptions as pygexc
@@ -491,7 +490,6 @@ class NodeHandler(immhandler.NodeHandler):
         # First check if the specified user is sha256...
         userinfo = await wc.grab_json_response('/api/dataset/imm_users')
         curruser = None
-        uid = None
         user = util.stringify(user)
         passwd = util.stringify(passwd)
         for userent in userinfo['items'][0]['users']:
@@ -508,7 +506,7 @@ class NodeHandler(immhandler.NodeHandler):
             try:
                 tpass = base64.b64encode(os.urandom(9)) + 'Iw47$'
                 userparams = "{0},6pmu0ezczzcp,{1},1,4,0,0,0,0,,8,".format(tmpuid, tpass)
-                result = await wc.grab_json_response('/api/function', {'USER_UserCreate': userparams})
+                await wc.grab_json_response('/api/function', {'USER_UserCreate': userparams})
                 await wc.grab_json_response('/api/providers/logout')
                 adata = {
                     'username': '6pmu0ezczzcp',

--- a/confluent_server/confluent/discovery/handlers/xcc3.py
+++ b/confluent_server/confluent/discovery/handlers/xcc3.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import confluent.discovery.handlers.redfishbmc as redfishbmc
-import confluent.util as util
 import socket
 import aiohmi.util.webclient as webclient
 

--- a/confluent_server/confluent/discovery/protocols/mdns.py
+++ b/confluent_server/confluent/discovery/protocols/mdns.py
@@ -29,17 +29,12 @@
 
 
 import asyncio
-import confluent.config.configmanager as cfm
-import confluent.collective.manager as collective
 import confluent.neighutil as neighutil
-import confluent.noderange as noderange
 import confluent.util as util
 import confluent.log as log
-import confluent.netutil as netutil
 import confluent.tasks as tasks
 import socket
 import os
-import time
 import struct
 import traceback
 
@@ -51,7 +46,6 @@ mcastv6addr = 'ff02::fb'
 mdns6mcast = socket.inet_pton(socket.AF_INET6, mcastv6addr)
 
 def name_to_qname(name):
-    nameparts = name.split('.')
     qname = b''
     for namepart in name.split('.'):
         namepart = namepart.encode('utf8')
@@ -132,7 +126,7 @@ async def snoop(handler, byehandler=None, protocol=None, uuidlookup=None):
     net4.bind(('', 5353))
     try:
         await active_scan(handler, protocol)
-    except Exception as e:
+    except Exception:
         tracelog.log(traceback.format_exc(), ltype=log.DataTypes.event,
                     event=log.Events.stacktrace)
     known_peers = set([])
@@ -180,7 +174,7 @@ async def snoop(handler, byehandler=None, protocol=None, uuidlookup=None):
                 if peer in recent_peers:
                     continue
                 mac = await neighutil.get_hwaddr(peer[0])
-                if mac == False:
+                if mac is False:
                     continue
                 if not mac:
                     probepeer = (peer[0], struct.unpack('H', os.urandom(2))[0] | 1025) + peer[2:]
@@ -316,7 +310,8 @@ async def active_scan(handler, protocol=None):
 
 async def check_fish(urldata, port=443, verifycallback=None):
     if not verifycallback:
-        verifycallback = lambda x: True
+        def verifycallback(x):
+            return True
     url, data = urldata
     try:
         wc = webclient.WebConnection(_get_svrip(data), port, verifycallback=verifycallback, timeout=1.5)

--- a/confluent_server/confluent/discovery/protocols/pxe.py
+++ b/confluent_server/confluent/discovery/protocols/pxe.py
@@ -45,7 +45,6 @@ import socket
 import struct
 import time
 import uuid
-import confluent.tasks as tasks
 
 libc = ctypes.CDLL(ctypes.util.find_library('c'))
 
@@ -199,7 +198,6 @@ def v6opts_to_dict(rq):
         if struct.unpack('!H', duid[:2])[0] == 4:
             disco['uuid'] = decode_uuid(duid[2:])
     if 61 in reqdict:
-        arch = bytes(rq[optidx+4:optidx+4+optlen])
         disco['arch'] = pxearchs.get(bytes(reqdict[61]), None)
     return reqdict, disco
 
@@ -362,7 +360,7 @@ async def proxydhcp(handler, nodeguess):
             rpv[249:268] = b'\x61\x11' + opts[97]
             rpv[268:280] = b'\x3c\x09PXEClient\xff'
             net4011.sendto(rpv[:281], client)
-        except Exception as e:
+        except Exception:
             log.logtrace()
             # tracelog.log(traceback.format_exc(), ltype=log.DataTypes.event,
             #                event=log.Events.stacktrace)
@@ -731,7 +729,7 @@ async def reply_dhcp4(node, info, packet, cfg, reqview, httpboot, cfd, profile, 
         log.log({'error': nicerr})
     if niccfg.get('ipv4_broken', False):
         # Received a request over a nic with no ipv4 configured, ignore it
-        log.log({'error': 'Skipping boot reply to {0} due to no viable IPv4 configuration on deployment system on interface index "{}"'.format(node, info['netinfo']['ifidx'])})
+        log.log({'error': 'Skipping boot reply to {0} due to no viable IPv4 configuration on deployment system on interface index "{1}"'.format(node, info['netinfo']['ifidx'])})
         return
     clipn = None
     if niccfg['ipv4_method'] == 'firmwarenone':
@@ -924,7 +922,7 @@ def ack_request(pkt, rq, info, sock=None, requestor=None):
     if not myipn or pkt.get(54, None) != myipn:
         return
     assigninfo = staticassigns.get(hwaddr, None)
-    if assigninfo == None:
+    if assigninfo is None:
         return
     if pkt.get(50, None) != assigninfo[0]:
         return

--- a/confluent_server/confluent/discovery/protocols/slp.py
+++ b/confluent_server/confluent/discovery/protocols/slp.py
@@ -247,15 +247,14 @@ async def _find_srvtype(net, net4, srvtype, addresses, xid):
                            socket.inet_aton(addr))
             try:
                 net4.sendto(data, ('239.255.255.253', 427))
-            except socket.error as se:
+            except socket.error:
                 pass
             try:
                 net4.sendto(data, (bcast, 427))
-            except socket.error as se:
+            except socket.error:
                 pass
 
 
-import time
 
 def sock_read(fut, sock, cloop, allsocks):
     if fut.done():
@@ -363,14 +362,14 @@ async def _add_attributes(parsed):
         net.settimeout(0)
         net.setblocking(0)
         await asyncio.wait_for(cloop.sock_connect(net, target), 2.0)
-    except (socket.error, asyncio.exceptions.TimeoutError) as te:
+    except (socket.error, asyncio.exceptions.TimeoutError):
         return
     try:
         await cloop.sock_sendall(net, attrq)
         rsp = await cloop.sock_recv(net, 8192)
         net.close()
         _parse_attrs(rsp, parsed, xid)
-    except Exception as e:
+    except Exception:
         # this can be a messy area, just degrade the quality of rsp
         # in a bad situation
         return
@@ -402,7 +401,7 @@ async def query_srvtypes(target):
             net.settimeout(0)
             await asyncio.wait_for(cloop.sock_connect(net, target), 2.0)
             connected = True
-        except (socket.error, asyncio.exceptions.TimeoutError) as te:
+        except (socket.error, asyncio.exceptions.TimeoutError):
             return [u'']
     await cloop.sock_sendall(net, packet)
     rs = await cloop.sock_recv(net, 8192)
@@ -434,7 +433,7 @@ def relay_packet(sock, pktq):
     sock.setblocking(0)
     try:
         rsp, peer = sock.recvfrom(9000)
-    except socket.error as se:
+    except socket.error:
         return
     pktq.put_nowait((sock, rsp, peer))
 
@@ -449,7 +448,7 @@ async def snoop(handler, protocol=None):
     tracelog = log.Logger('trace')
     try:
         await active_scan(handler, protocol)
-    except Exception as e:
+    except Exception:
         tracelog.log(traceback.format_exc(), ltype=log.DataTypes.event,
                         event=log.Events.stacktrace)
     net = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
@@ -498,8 +497,6 @@ async def snoop(handler, protocol=None):
             known_peers.clear()
             peerbymacaddress.clear()
             deferpeers.clear()
-            timeo = 60
-            rdy = True
             srp = await pktq.get()
             while srp and len(deferpeers) < 256:
                 s, rsp, peer = srp
@@ -517,7 +514,7 @@ async def snoop(handler, protocol=None):
                     try:
                         s.setblocking(1)
                         s.sendto(b'\x00', probepeer)
-                    except Exception as e:
+                    except Exception:
                         continue
                     deferpeers.append(peer)
                     continue
@@ -546,7 +543,7 @@ async def snoop(handler, protocol=None):
                     else:
                         continue
                 handler(peerbymacaddress[mac])
-        except Exception as e:
+        except Exception:
             tracelog.log(traceback.format_exc(), ltype=log.DataTypes.event,
                          event=log.Events.stacktrace)
 
@@ -560,7 +557,7 @@ async def process_peer(newmacs, known_peers, peerbymacaddress, peer):
     else:
         try:
             q = await query_srvtypes(peer)
-        except Exception as e:
+        except Exception:
             q = None
         if not q or not q[0]:
             # SLP might have started and not ready yet
@@ -637,7 +634,6 @@ async def scan(srvtypes=_slp_services, addresses=None, localonly=False):
     # processed, mitigating volume of response traffic
     rsps = {}
     deferrals = []
-    rcvq = asyncio.Queue()
     for srvtype in srvtypes:
         xididx += 1
         await _find_srvtype(net, net4, srvtype, addresses, initxid + xididx)

--- a/confluent_server/confluent/discovery/protocols/ssdp.py
+++ b/confluent_server/confluent/discovery/protocols/ssdp.py
@@ -155,7 +155,7 @@ async def snoop(handler, byehandler=None, protocol=None, uuidlookup=None):
     cloop = asyncio.get_running_loop()
     try:
         await active_scan(handler, protocol)
-    except Exception as e:
+    except Exception:
         tracelog.log(traceback.format_exc(), ltype=log.DataTypes.event,
                     event=log.Events.stacktrace)
     known_peers = set([])
@@ -220,7 +220,7 @@ async def snoop(handler, byehandler=None, protocol=None, uuidlookup=None):
                         continue
                     recent_peers.add(peer)
                     mac = await neighutil.get_hwaddr(peer[0])
-                    if mac == False:
+                    if mac is False:
                         # neighutil determined peer ip is not local, skip attempt
                         # to probe and critically, skip growing deferrednotifiers
                         continue
@@ -346,7 +346,7 @@ def _relay_pkt(sock, pktq):
     sock.setblocking(0)
     try:
         rsp, peer = sock.recvfrom(9000)
-    except socket.error as se:
+    except socket.error:
         return
     pktq.put_nowait((sock, rsp, peer))
 
@@ -488,7 +488,8 @@ async def _find_service(service, target):
 
 async def check_fish(urldata, port=443, verifycallback=None):
     if not verifycallback:
-        verifycallback = lambda x: True
+        def verifycallback(x):
+            return True
     try:
         url, data, targtype = urldata
     except ValueError:
@@ -609,5 +610,4 @@ if __name__ == '__main__':
     def printit(rsp):
         pass # print(repr(rsp))
     asyncio.run(active_scan(printit))
-
 

--- a/confluent_server/confluent/httpapi.py
+++ b/confluent_server/confluent/httpapi.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     webauthn = None
 import asyncio
-from aiohttp import web, web_urldispatcher, connector, ClientSession, WSMsgType
+from aiohttp import web, WSMsgType
 import confluent.auth as auth
 import confluent.config.attributes as attribs
 import confluent.config.configmanager as configmanager
@@ -185,7 +185,6 @@ async def _sessioncleaner():
 
 def _get_query_dict(req, reqbody, reqtype):
     qdict = {}
-    qstring = req.rel_url.query_string
     qdict.update(req.rel_url.query)
     if reqbody is not None:
         if "application/x-www-form-urlencoded" in reqtype:

--- a/confluent_server/confluent/log.py
+++ b/confluent_server/confluent/log.py
@@ -63,13 +63,11 @@
 #    (a future extended version might include suport for Forward Secure Sealing
 #    or other fields)
 
-import asyncio
 import collections
 import confluent.config.configmanager
 import confluent.config.conf as conf
 import confluent.exceptions as exc
 import confluent.tasks as tasks
-import inspect
 import glob
 import json
 import os
@@ -78,7 +76,6 @@ import stat
 import struct
 import time
 import traceback
-import random
 try:
     unicode
 except NameError:
@@ -171,7 +168,7 @@ class BaseRotatingHandler(object):
                 flock(self.textfile, LOCK_UN)
                 return self.doRollover(rolling_type)
             return None
-        except (IOError, OSError) as e:
+        except (IOError, OSError):
             if not daemonized:
                 raise
             logfull = True
@@ -190,7 +187,7 @@ class BaseRotatingHandler(object):
             self.binfile.write(binrecord)
             self.textfile.flush()
             self.binfile.flush()
-        except (IOError, OSError) as e:
+        except (IOError, OSError):
             if not daemonized:
                 raise
             logfull = True
@@ -727,7 +724,7 @@ class Logger(object):
                     textfile.close()
                     textfile = open(textpath, mode='r')
                     flock(textfile, LOCK_SH)
-                except (ValueError, IOError) as e:
+                except (ValueError, IOError):
                     break
             try:
                 textfile.seek(offset, 0)

--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -42,7 +42,6 @@ import confluent.core as confluentcore
 import confluent.httpapi as httpapi
 import confluent.log as log
 import confluent.collective.manager as collective
-import confluent.discovery.protocols.pxe as pxe
 import linecache
 try:
     import confluent.sockapi as sockapi
@@ -58,7 +57,6 @@ except ImportError:
     havefcntl = False
 #import multiprocessing
 import asyncio
-import gc
 import sys
 import os
 import glob
@@ -102,7 +100,7 @@ def format_stack(task):
 
 
 def _daemonize():
-    if not 'fork' in os.__dict__:
+    if 'fork' not in os.__dict__:
         return
     thispid = os.fork()
     if thispid > 0:

--- a/confluent_server/confluent/neighutil.py
+++ b/confluent_server/confluent/neighutil.py
@@ -18,7 +18,6 @@
 
 import asyncio
 import confluent.netutil as netutil
-import confluent.util as util
 import os
 import socket
 import struct
@@ -31,7 +30,6 @@ def msg_align(len):
 neightable = {}
 neightime = 0
 
-import re
 
 neighlock = asyncio.Lock()
 
@@ -103,7 +101,7 @@ async def get_hwaddr(ipaddr):
         hwaddr = neightable.get(ipaddr, None)
         if not hwaddr and not await netutil.ipn_is_local(ipaddr):
             hwaddr = False
-        if hwaddr == None and not updated:
+        if hwaddr is None and not updated:
             await _update_neigh()
             hwaddr = neightable.get(ipaddr, None)
     if hwaddr:

--- a/confluent_server/confluent/netutil.py
+++ b/confluent_server/confluent/netutil.py
@@ -301,7 +301,6 @@ class NetManager(object):
             del self.myattribs[netname]
             return
         if ipv4addr:
-            prefixlen = None
             if '/' in ipv4addr:
                 ipv4addr, _ = ipv4addr.split('/', 1)
             ipv4bytes = socket.inet_pton(socket.AF_INET, ipv4addr.split('/')[0])
@@ -678,7 +677,7 @@ async def get_nic_config(configmanager, node, ip=None, mac=None, ifidx=None,
             if not cfgdata.get('ipv6_method', None):
                 cfgdata['ipv6_method'] = 'dhcp'
             return noneify(cfgdata)
-        if ipbynodename == None and ip6bynodename == None:
+        if ipbynodename is None and ip6bynodename is None:
             return noneify(cfgdata)
         for myaddr in myaddrs:
             fam, svrip, prefix = myaddr[:3]

--- a/confluent_server/confluent/networking/lldp.py
+++ b/confluent_server/confluent/networking/lldp.py
@@ -32,7 +32,6 @@
 
 if __name__ == '__main__':
     import sys
-    import confluent.config.configmanager as cfm
 import asyncio
 import base64
 import confluent.networking.nxapi as nxapi
@@ -296,7 +295,7 @@ async def _extract_neighbor_data_b(args):
     lldpdata = {'!!vintage': now}
     try:
         return await _extract_neighbor_data_https(switch, user, password, cfm, lldpdata)
-    except Exception as e:
+    except Exception:
         pass
     conn = snmp.Session(switch, password, user, privacy_protocol=privproto)
     sid = None

--- a/confluent_server/confluent/networking/macmap.py
+++ b/confluent_server/confluent/networking/macmap.py
@@ -57,7 +57,6 @@ import confluent.tasks as tasks
 import confluent.networking.nxapi as nxapi
 import confluent.networking.srlinux as srlinux
 import confluent.util as util
-import fcntl
 import msgpack
 import random
 import re
@@ -135,7 +134,7 @@ async def _map_switch(args):
     except exc.TargetEndpointBadCredentials:
         log.log({'error': "Bad SNMPv3 credentials for \'{0}\'".format(
             args[0])})
-    except Exception as e:
+    except Exception:
         log.log({'error': 'Unexpected condition trying to reach switch "{0}"'
                           ' check trace log for more'.format(args[0])})
         log.logtrace()
@@ -302,7 +301,7 @@ async def _map_switch_backend(args):
                               'from {0}, the TLS certificate failed validation. '
                               'Clear pubkeys.tls_hardwaremanager if this was '
                               'expected due to reinstall or new certificate'.format(switch)})
-        except Exception as e:
+        except Exception:
             pass
     mactobridge, ifnamemap, bridgetoifmap = await _offload_map_switch(
         switch, password, user, privprotocol)
@@ -390,7 +389,6 @@ async def _snmp_map_switch_relay(rqid, switch, password, user, privprotocol=None
         except AttributeError:
             sys.stdout.write(payload)
     except Exception as e:
-        import traceback
         payload = msgpack.packb((rqid, 2, str(e)), use_bin_type=True)
         try:
             sys.stdout.buffer.write(payload)

--- a/confluent_server/confluent/networking/nxapi.py
+++ b/confluent_server/confluent/networking/nxapi.py
@@ -80,7 +80,8 @@ class NxApiClient:
                 configmanager, switch, 'pubkeys.tls_hardwaremanager'
             ).verify_cert
         else:
-            cv = lambda x: True
+            def cv(x):
+                return True
         self.user = user
         self.password = password
         try:

--- a/confluent_server/confluent/networking/srlinux.py
+++ b/confluent_server/confluent/networking/srlinux.py
@@ -13,7 +13,8 @@ class SRLinuxClient:
                 configmanager, switch, 'pubkeys.tls_hardwaremanager'
             ).verify_cert
         else:
-            cv = lambda x: True
+            def cv(x):
+                return True
         self.user = user
         self.password = password
         try:

--- a/confluent_server/confluent/noderange.py
+++ b/confluent_server/confluent/noderange.py
@@ -88,7 +88,6 @@ class Bracketer(object):
     def extend(self, nodeorseq):
         # can only differentiate a single number
         endname = None
-        endnums = None
         if ':' in nodeorseq:
             nodename, endname = nodeorseq.split(':', 1)
         else:
@@ -280,7 +279,7 @@ class NodeRange(object):
         self.purenumeric = purenumeric
         try:
             elements = _parser.parseString("(" + noderange + ")", parseAll=True).asList()[0]
-        except pp.ParseException as pe:
+        except pp.ParseException:
             raise Exception("Invalid syntax")
         if noderange[0] in ('<', '>'):
             # pagination across all nodes

--- a/confluent_server/confluent/osimage.py
+++ b/confluent_server/confluent/osimage.py
@@ -50,7 +50,7 @@ HASHPRINTS = {
 from ctypes import byref, c_longlong, c_size_t, c_void_p
 
 from libarchive.ffi import (
-    write_disk_new, write_disk_set_options, write_free, write_header,
+    write_header,
     read_data_block, write_data_block, write_finish_entry, ARCHIVE_EOF
 )
 
@@ -1262,7 +1262,7 @@ class MediaImporter(object):
     async def importmedia(self):
         if self.medfile:
             os.environ['CONFLUENT_MEDIAFD'] = '{0}'.format(self.medfile.fileno())
-        with open(os.devnull, 'w') as devnull:
+        with open(os.devnull, 'w'):
             self.worker = await asyncio.create_subprocess_exec(
                 sys.executable, __file__, self.filename, '-b',
                 self.targpath, self.distpath, self.customname,
@@ -1340,4 +1340,3 @@ if __name__ == '__main__':
         asyncio.run(import_image(sys.argv[1], callback=printit, backend=True, mfd=mfd, custtargpath=sys.argv[3], custdistpath=sys.argv[4], custname=sys.argv[5]))
     else:
         asyncio.run(import_image(sys.argv[1], callback=printit))
-

--- a/confluent_server/confluent/pam.py
+++ b/confluent_server/confluent/pam.py
@@ -233,7 +233,8 @@ def authenticate(*vargs, **dargs):
 
 
 if __name__ == "__main__":
-    import readline, getpass
+    import readline
+    import getpass
 
     def input_with_prefill(prompt, text):
         def hook():

--- a/confluent_server/confluent/plugins/console/openbmc.py
+++ b/confluent_server/confluent/plugins/console/openbmc.py
@@ -22,11 +22,9 @@
 import asyncio
 import confluent.exceptions as cexc
 import confluent.interface.console as conapi
-import confluent.log as log
 import confluent.tasks as tasks
 import confluent.util as util
 import aiohmi.exceptions as pygexc
-import aiohmi.redfish.command as rcmd
 import aiohmi.util.webclient as webclient
 import aiohttp
 

--- a/confluent_server/confluent/plugins/console/tsmsol.py
+++ b/confluent_server/confluent/plugins/console/tsmsol.py
@@ -22,7 +22,6 @@
 import asyncio
 import confluent.exceptions as cexc
 import confluent.interface.console as conapi
-import confluent.log as log
 import confluent.tasks as tasks
 import confluent.util as util
 import aiohmi.exceptions as pygexc
@@ -109,7 +108,6 @@ class TsmConsole(conapi.Console):
         self.datacallback = callback
         kv = util.TLSCertVerifier(
             self.nodeconfig, self.node, 'pubkeys.tls_hardwaremanager').verify_cert
-        wc = webclient.WebConnection(self.origbmc, 443, verifycallback=kv)
         try:
             rc = rcmd.Command(self.origbmc, self.username,
                               self.password,

--- a/confluent_server/confluent/plugins/hardwaremanagement/cnos.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/cnos.py
@@ -109,7 +109,6 @@ async def retrieve_health(configmanager, creds, node, results):
     if summary == 'noncritical':
         summary = 'warning'
     await results.put(msg.HealthSummary(summary, name=node))
-    state = None
     badreadings = []
     if summary != 'ok':  # temperature or dump or fans or psu
         await wc.grab_json_response('/nos/api/sysinfo/panic_dump')
@@ -172,7 +171,6 @@ async def retrieve(nodes, element, configmanager, inputdata):
         for node in nodes:
             yield msg.ConfluentNodeError(node, 'Not Implemented')
         return
-    currtimeout = 10
     while workers:
         try:
             datum = await asyncio.wait_for(results.get(), timeout=10)

--- a/confluent_server/confluent/plugins/hardwaremanagement/cooltera.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/cooltera.py
@@ -15,7 +15,6 @@
 from lxml import etree
 import confluent.util as util
 import confluent.messages as msg
-import confluent.exceptions as exc
 import confluent.tasks as tasks
 import aiohmi.util.webclient as wc
 import time

--- a/confluent_server/confluent/plugins/hardwaremanagement/deltapdu.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/deltapdu.py
@@ -15,7 +15,6 @@
 #TODO: ASYNC asyncio conversion
 import asyncio
 
-import confluent.util as util
 import confluent.messages as msg
 import confluent.exceptions as exc
 import lxml.etree as etree

--- a/confluent_server/confluent/plugins/hardwaremanagement/eatonpdu.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/eatonpdu.py
@@ -17,9 +17,7 @@ import asyncio
 import base64
 import confluent.util as util
 import confluent.messages as msg
-import confluent.exceptions as exc
 import aiohmi.util.webclient as wc
-import confluent.util as util
 import re
 import hashlib
 import json
@@ -201,7 +199,7 @@ class PDUClient(object):
         try:
             self._wc = WebConnection(target, secure=True, verifycallback=verifier.verify_cert)
             self.login(self.configmanager)
-        except socket.error as e:
+        except socket.error:
             pkey = self.configmanager.get_node_attributes(self.node, 'pubkeys.tls_hardwaremanager')
             pkey = pkey.get(self.node, {}).get('pubkeys.tls_hardwaremanager', {}).get('value', None)
             if pkey:
@@ -250,7 +248,7 @@ class PDUClient(object):
             )
         rsp = self.wc.grab_response(url)
         rsp = json.loads(sanitize_json(rsp[0]))
-        if rsp['success'] != True:
+        if not rsp['success']:
             raise Exception('Failed to login to device')
         rsp = self.wc.grab_response('/config/gateway?page=cgi_checkUserSession&sessionId={}&_dc={}'.format(self.sessid, int(time.time())))
 

--- a/confluent_server/confluent/plugins/hardwaremanagement/enlogic.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/enlogic.py
@@ -16,7 +16,6 @@ import asyncio
 
 import confluent.util as util
 import confluent.messages as msg
-import confluent.exceptions as exc
 import aiohmi.util.webclient as wc
 import confluent.tasks as tasks
 import time
@@ -135,7 +134,7 @@ class EnlogicClient(object):
             'pduid': 1,
             'powstat': state
             }
-        rsp = await self.grab_json_response('/xhroutpowstatset.jsp', request)
+        await self.grab_json_response('/xhroutpowstatset.jsp', request)
 
 
 _sensors_by_node = {}

--- a/confluent_server/confluent/plugins/hardwaremanagement/enos.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/enos.py
@@ -26,7 +26,6 @@ import asyncio
 import confluent.tasks as tasks
 import confluent.exceptions as exc
 import confluent.messages as msg
-import confluent.util as util
 import confluent.plugins.shell.ssh as ssh
 
 
@@ -109,7 +108,6 @@ async def retrieve(nodes, element, configmanager, inputdata):
         for node in nodes:
             yield msg.ConfluentNodeError(node, f"Not Implemented: {element}")
         return
-    currtimeout = 10
     while workers:
         try:
             datum = await results.get()
@@ -252,7 +250,7 @@ def gather_psus(data):
         # others are:
         # Internal  Power Supply: On
         if "Power Supply" in line:
-            match = re.match(re.compile(f"Power Supply (\d)+.*"), line)
+            match = re.match(re.compile("Power Supply (\d)+.*"), line)
             if match:
                 psu = match.group(1)
                 if psu not in psus:
@@ -282,7 +280,7 @@ def gather_fans(data):
     for line in data:
         # look for presence of fans
         if "Fan" in line:
-            match = re.match(re.compile(f"Fan (\d)+.*"), line)
+            match = re.match(re.compile("Fan (\d)+.*"), line)
             if match:
                 fan = match.group(1)
                 if match:

--- a/confluent_server/confluent/plugins/hardwaremanagement/geist.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/geist.py
@@ -15,7 +15,6 @@
 import asyncio
 import confluent.util as util
 import confluent.messages as msg
-import confluent.exceptions as exc
 import aiohmi.util.webclient as wc
 import confluent.tasks as tasks
 import time

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import asyncio
-import atexit
 import confluent.exceptions as exc
 import confluent.firmwaremanager as firmwaremanager
 import confluent.interface.console as conapi
@@ -1677,7 +1676,7 @@ class IpmiHandler:
             if mybmc.startswith('fe80::'):  # link local, need to adjust
                 lancfg = await self.ipmicmd.get_net_configuration()
                 mybmc = lancfg['ipv4_address'].split('/')[0]
-            if ':' in mybmc and not '[' in mybmc:
+            if ':' in mybmc and '[' not in mybmc:
                 mybmc = '[{}]'.format(mybmc)
             launchdata['url'] = 'https://{}{}'.format(mybmc, launchdata['url'])
         await self.output.put(msg.KeyValueData(launchdata, self.node))

--- a/confluent_server/confluent/plugins/hardwaremanagement/proxmox.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/proxmox.py
@@ -39,7 +39,7 @@ class KvmConnection:
         #self.ws = WrappedWebSocket(host=bmc)
         #self.ws.set_verify_callback(kv)
         ticket = consdata['ticket']
-        user = consdata['user']
+        #user = consdata['user']
         port = consdata['port']
         urlticket = urlparse.quote(ticket)
         host = consdata['host']
@@ -173,7 +173,8 @@ class PmxApiClient:
                 configmanager, server, 'pubkeys.tls'
             ).verify_cert
         else:
-            cv = lambda x: True
+            def cv(x):
+                return True
 
         try:
             self.user = self.user.decode()
@@ -232,7 +233,6 @@ class PmxApiClient:
     async def get_vm_inventory(self, vm):
         host, guest = await self.get_vm(vm)
         cfg = await self.wc.grab_json_response(f'/api2/json/nodes/{host}/{guest}/pending')
-        myuuid = None
         sysinfo = {'name': 'System', 'present': True, 'information': {
             'Product name': 'Proxmox qemu virtual machine',
             'Manufacturer': 'qemu'
@@ -335,7 +335,7 @@ class PmxApiClient:
                     state = ''
                     newstate = 'reset'
         if state:
-            rsp = await self.wc.grab_json_response_with_status(f'/api2/json/nodes/{host}/{guest}/status/{state}', method='POST')
+            await self.wc.grab_json_response_with_status(f'/api2/json/nodes/{host}/{guest}/status/{state}', method='POST')
         if state and state != 'reset':
             newstate = await self.get_vm_power(vm)
             while newstate != targstate:
@@ -486,7 +486,6 @@ async def create(nodes, element, configmanager, inputdata):
 if __name__ == '__main__':
     import sys
     import os
-    from pprint import pprint
     myuser = os.environ['PMXUSER']
     mypass = os.environ['PMXPASS']
     vc = PmxApiClient(sys.argv[1], myuser, mypass, None)

--- a/confluent_server/confluent/plugins/hardwaremanagement/raritan.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/raritan.py
@@ -18,10 +18,8 @@ import asyncio
 import base64
 import confluent.util as util
 import confluent.messages as msg
-import confluent.exceptions as exc
 import aiohmi.util.webclient as wc
 import confluent.tasks as tasks
-import json
 import time
 
 
@@ -92,7 +90,6 @@ class RaritanClient(object):
     async def get_wc_with_session(self):
         if self._authtoken and self._authvintage and time.time() - self._authvintage < 90:
             return self._wc
-        wc = self.wc
         if not self._username or not self._password:
             credcfg = self.configmanager.get_node_attributes(
                 self.node,

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -208,7 +208,7 @@ class IpmiCommandWrapper(ipmicommand.Command):
         self._inhealth = True
         try:
             self._lasthealth = await super(IpmiCommandWrapper, self).get_health()
-        except Exception as e:
+        except Exception:
             self._inhealth = False
             raise
         self._inhealth = False
@@ -1620,7 +1620,7 @@ class IpmiHandler:
             if mybmc.startswith('fe80::'):  # link local, need to adjust
                 lancfg = await self.ipmicmd.get_net_configuration()
                 mybmc = lancfg['ipv4_address'].split('/')[0]
-            if ':' in mybmc and not '[' in mybmc:
+            if ':' in mybmc and '[' not in mybmc:
                 mybmc = '[{}]'.format(mybmc)
             launchdata['url'] = 'https://{}{}'.format(mybmc, launchdata['url'])
         await self.output.put(msg.KeyValueData(launchdata, self.node))

--- a/confluent_server/confluent/plugins/hardwaremanagement/srlinux.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/srlinux.py
@@ -8,7 +8,7 @@ import confluent.tasks as tasks
 async def retrieve_node(node, element, user, pwd, configmanager, inputdata, results):
     try:
         await retrieve_node_backend(node, element, user, pwd, configmanager, inputdata, results)
-    except exc.PubkeyInvalid as e:
+    except exc.PubkeyInvalid:
         await results.put(msg.ConfluentNodeError(node, 'Mismatch detected between target certificate fingerprint '
                 'and pubkeys.tls_hardwaremanager attribute'))
     except Exception as e:

--- a/confluent_server/confluent/plugins/hardwaremanagement/vcenter.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/vcenter.py
@@ -137,7 +137,8 @@ class VmwApiClient:
                 configmanager, vcsa, 'pubkeys.tls_hardwaremanager'
             ).verify_cert
         else:
-            cv = lambda x: True
+            def cv(x):
+                return True
 
         try:
             self.user = self.user.decode()
@@ -206,7 +207,6 @@ class VmwApiClient:
         hwver = rawinv['hardware']['version']
         uuid = fixuuid(rawinv['identity']['bios_uuid'])
         serial = rawinv['identity']['instance_uuid']
-        invitems = []
         sysinfo = {'name': 'System',
                    'present': True,
                    'information': {
@@ -237,7 +237,7 @@ class VmwApiClient:
     async def get_vm_host(self, vm):
         # unfortunately, the REST api doesn't manifest this as a simple attribute,
         vm = await self.index_vm(vm)
-        rsp = await self.wc.grab_json_response(f'/api/vcenter/host')
+        rsp = await self.wc.grab_json_response('/api/vcenter/host')
         for hostinfo in rsp:
             host = hostinfo['host']
             rsp = await self.wc.grab_json_response(f'/api/vcenter/vm?hosts={host}')
@@ -308,7 +308,7 @@ class VmwApiClient:
             state = 'start'
         elif state == 'off':
             state = 'stop'
-        rsp = await self.wc.grab_json_response_with_status(f'/api/vcenter/vm/{vm}/power?action={state}', method='POST')
+        await self.wc.grab_json_response_with_status(f'/api/vcenter/vm/{vm}/power?action={state}', method='POST')
         return targstate, current
 
 
@@ -333,10 +333,10 @@ class VmwApiClient:
                 for nic in currnics:
                     bootdevs.append({'type': 'ETHERNET', 'nic': nic['nic']})
             payload = {'devices': bootdevs}
-            rsp = await self.wc.grab_json_response_with_status(f'/api/vcenter/vm/{vm}/hardware/boot/device',
+            await self.wc.grab_json_response_with_status(f'/api/vcenter/vm/{vm}/hardware/boot/device',
                                                         payload,
                                                         method='PUT')
-            rsp = await self.wc.grab_json_response_with_status(f'/api/vcenter/vm/{vm}/hardware/boot',
+            await self.wc.grab_json_response_with_status(f'/api/vcenter/vm/{vm}/hardware/boot',
                                                         {'enter_setup_mode': entersetup},
                                                         method='PATCH')
         finally:
@@ -414,7 +414,6 @@ async def create(nodes, element, configmanager, inputdata):
 if __name__ == '__main__':
     import sys
     import os
-    from pprint import pprint
     myuser = os.environ['VMWUSER']
     mypass = os.environ['VMWPASS']
     vc = VmwApiClient(sys.argv[1], myuser, mypass, None)

--- a/confluent_server/confluent/plugins/shell/ssh.py
+++ b/confluent_server/confluent/plugins/shell/ssh.py
@@ -21,14 +21,10 @@
 
 import confluent.exceptions as cexc
 import confluent.interface.console as conapi
-import confluent.log as log
 import confluent.tasks as tasks
-import confluent.util as util
 
-import hashlib
 import sys
 sys.modules['gssapi'] = None
-import asyncio
 import asyncssh
 
 

--- a/confluent_server/confluent/sockapi.py
+++ b/confluent_server/confluent/sockapi.py
@@ -28,7 +28,6 @@ import errno
 import os
 import pwd
 import shutil
-import stat
 import struct
 import sys
 import traceback
@@ -509,7 +508,6 @@ class SockApi(object):
         if self.should_run_remoteapi():
             self.start_remoteapi()
         else:
-            cloop = asyncio.get_running_loop()
             tasks.spawn(self.watch_for_cert())
         self.unixdomainserver = tasks.spawn_task(_unixdomainhandler(self.bind_group, self.bind_perms))
 

--- a/confluent_server/confluent/syncfiles.py
+++ b/confluent_server/confluent/syncfiles.py
@@ -63,7 +63,6 @@ def get_entries(filename):
 
 class SyncList(object):
     def __init__(self, filename, nodename, cfg):
-        slist = None
         self.replacemap = {}
         self.appendmap = {}
         self.appendoncemap = {}
@@ -206,7 +205,7 @@ async def sync_list_to_node(sl, node, suffixes, peerip=None):
                 try:
                     with open(filename, 'r') as _:
                         pass
-                except OSError as e:
+                except OSError:
                     unreadablefiles.append(filename.replace(targdir, ''))
         if unreadablefiles:
             raise Exception("Syncing failed due to unreadable files: " + ','.join(unreadablefiles))

--- a/confluent_server/confluent/userutil.py
+++ b/confluent_server/confluent/userutil.py
@@ -3,7 +3,6 @@ from ctypes.util import find_library
 import confluent.util as util
 import grp
 import pwd
-import os
 libc = cdll.LoadLibrary(find_library('c'))
 _getgrouplist = libc.getgrouplist
 _getgrouplist.restype = c_int32

--- a/confluent_server/confluent/util.py
+++ b/confluent_server/confluent/util.py
@@ -33,7 +33,6 @@ import re
 import socket
 import ssl
 import struct
-import random
 import subprocess
 import cryptography.x509 as x509
 try:
@@ -119,7 +118,7 @@ def get_bmc_subject_san(configmanager, nodename, addnames=()):
     dnsnames = set([])
     for addname in addnames:
         try:
-            addr = ipaddress.ip_address(addname)
+            ipaddress.ip_address(addname)
             ipas.add(addname)
         except Exception:
             dnsnames.add(addname)

--- a/confluent_server/confluent/vinzmanager.py
+++ b/confluent_server/confluent/vinzmanager.py
@@ -1,8 +1,6 @@
 
 import asyncio
 import confluent.auth as auth
-import confluent.messages as msg
-import confluent.exceptions as exc
 import confluent.tasks as tasks
 import confluent.util as util
 import confluent.config.configmanager as configmanager
@@ -142,7 +140,7 @@ async def send_grant(conn, nodename, rqtype):
                 bmcuser = bmcuser.decode()
             if not isinstance(bmcpass, str):
                 bmcpass = bmcpass.decode()
-            rsp = await wc.grab_json_response_with_status(
+            await wc.grab_json_response_with_status(
                 '/login', {'data': [bmcuser, bmcpass]},
                 headers={'Content-Type': 'application/json',
                         'Accept': 'application/json'})

--- a/confluent_server/confluent/webauthn.py
+++ b/confluent_server/confluent/webauthn.py
@@ -1,10 +1,8 @@
 import confluent.tlvdata as tlvdata
-import confluent.util as util
 import json
 import copy
 import base64
-import secrets, time
-from typing import Any, Optional
+import secrets
 from webauthn import (
     generate_registration_options, 
     options_to_json, 
@@ -34,7 +32,7 @@ def _load_credentials(creds):
 def _load_authenticators(authenticators):
     ret = authenticators
     if 'challenges' in ret:
-        if not ret['challenges'] is None:       
+        if ret['challenges'] is not None:       
             ret['challenges']['request'] = base64.b64decode(ret['challenges']['request'])
     if 'credentials' in ret:
         ret['credentials'] = _load_credentials(ret['credentials'])
@@ -179,7 +177,7 @@ async def registration_response(request, username, APP_RELYING_PARTY, APP_ORIGIN
         expected_rp_id=APP_RELYING_PARTY.id,
         expected_origin=APP_ORIGIN,
         )
-    except Exception as err:
+    except Exception:
         raise Exception("Could not handle credential attestation")
     
     credential = Credential(id=registration_verification.credential_id, public_key=registration_verification.credential_public_key)
@@ -292,5 +290,4 @@ async def handle_api_request(url, req, username, cfm, reqbody, authorized):
         rsp = await registration_response(req, username, APP_RELYING_PARTY, APP_ORIGIN)
         if rsp.get('verified', False):
             return json.dumps({'status': 'Success'})
-
 

--- a/misc/autocons.py
+++ b/misc/autocons.py
@@ -1,6 +1,5 @@
 import fcntl
 import os
-import signal
 import struct
 import subprocess
 import termios

--- a/misc/cfg-dhcp-redfish-bmcs-by-switch.py
+++ b/misc/cfg-dhcp-redfish-bmcs-by-switch.py
@@ -35,8 +35,6 @@ import sys
 sys.path.append('/opt/confluent/lib/python')
 import aiohmi.util.webclient as webclient
 import confluent.client as cli
-import json
-import os
 import struct
 import subprocess
 import time

--- a/misc/fixexpiry.py
+++ b/misc/fixexpiry.py
@@ -39,7 +39,6 @@ if rsp.status == 200:
          'USER_GlobalPassExpWarningPeriod': '0', 
          'USER_GlobalPassExpPeriod': '0', 
          'USER_GlobalMinPassReuseCycle': '0', 
-         'USER_GlobalMinPassReuseCycle': '0', 
          'USER_GlobalMinPassChgInt': '0', 
      })))
      print(repr(w.grab_json_response('/api/function', {'USER_UserPassChange': '1,' + os.environ['XCCPASS']})))

--- a/misc/getxcccsr.py
+++ b/misc/getxcccsr.py
@@ -3,7 +3,6 @@ import io
 import gzip
 import pyghmi.redfish.command as cmd
 import os
-import sys
 
 ap = argparse.ArgumentParser(description='Certificate Generate')
 ap.add_argument('xcc', help='XCC address')

--- a/misc/grabscreenshot.py
+++ b/misc/grabscreenshot.py
@@ -3,7 +3,6 @@ import pyghmi.redfish.command as ic
 import pyghmi.util.webclient as webclient
 import sys
 import os
-import time
 
 def iterm_draw(databuf):
     datalen = len(databuf)

--- a/misc/installxcccert.py
+++ b/misc/installxcccert.py
@@ -1,7 +1,6 @@
 import argparse
 import pyghmi.redfish.command as cmd
 import os
-import sys
 
 ap = argparse.ArgumentParser(description='Certificate Generate')
 ap.add_argument('xcc', help='XCC address')

--- a/misc/makealtca.py
+++ b/misc/makealtca.py
@@ -74,7 +74,7 @@ def create_alt_ca(certout, permitdomains):
     if nameconstraints:
         nameconstraints = f'nameConstraints = critical,{nameconstraints}\n'
     certutil.mkdirp('/etc/confluent/tls/ca-alt/newcerts')
-    with open('/etc/confluent/tls/ca-alt/index.txt', 'w') as idx:
+    with open('/etc/confluent/tls/ca-alt/index.txt', 'w'):
         pass
 
     with open(sslcfg, 'r') as cfgin:
@@ -100,4 +100,3 @@ def create_alt_ca(certout, permitdomains):
     )
 if __name__ == '__main__':
     create_alt_ca(sys.argv[1], sys.argv[2].split(','))
-

--- a/misc/prepfish.py
+++ b/misc/prepfish.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import ctypes
 import fcntl
 import json
@@ -26,7 +25,6 @@ import subprocess
 import sys
 import time
 import ssl
-import socket
 
 class IpmiMsg(ctypes.Structure):
     _fields_ = [('netfn', ctypes.c_ubyte),
@@ -108,7 +106,6 @@ def scan_nicname(nicname):
 def scan_nic(nicidx):
     iplinkinfo = subprocess.check_output(['ip', '-j', 'link'], stderr=subprocess.DEVNULL)
     iplinkinfo = json.loads(iplinkinfo.decode())
-    lilkelylla = None
     for link in iplinkinfo:
         if link['ifindex'] == nicidx:
             mac = link['address']
@@ -124,7 +121,6 @@ def scan_nic(nicidx):
                     return likelylla
             except Exception:
                 pass
-    srvs = {}
     s6 = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
     s6.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
     s6.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
@@ -238,7 +234,7 @@ def dotwait():
 
 def disable_host_interface():
     s = Session('/dev/ipmi0')
-    rsp = s.raw_command(netfn=0xc, command=1, data=(1, 0xc1, 0))
+    s.raw_command(netfn=0xc, command=1, data=(1, 0xc1, 0))
 
 def get_redfish_creds():
     os.makedirs('/run/redfish', exist_ok=True, mode=0o700)

--- a/misc/setinitalpwd.py
+++ b/misc/setinitalpwd.py
@@ -29,7 +29,6 @@ if rsp.status == 200:
          'USER_GlobalPassExpWarningPeriod': '0', 
          'USER_GlobalPassExpPeriod': '0', 
          'USER_GlobalMinPassReuseCycle': '0', 
-         'USER_GlobalMinPassReuseCycle': '0', 
          'USER_GlobalMinPassChgInt': '0', 
      })))
      #print(repr(w.grab_json_response('/api/function', {'USER_UserPassChange': '1,' + os.environ['XCCPASS']})))

--- a/misc/slpscan.py
+++ b/misc/slpscan.py
@@ -363,7 +363,7 @@ def _add_attributes(parsed):
         rsp = net.recv(8192)
         net.close()
         _parse_attrs(rsp, parsed, xid)
-    except Exception as e:
+    except Exception:
         # this can be a messy area, just degrade the quality of rsp
         # in a bad situation
         return
@@ -434,7 +434,7 @@ def snoop(handler, protocol=None):
     """
     try:
         active_scan(handler, protocol)
-    except Exception as e:
+    except Exception:
         raise
     net = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
     net.setsockopt(IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
@@ -529,7 +529,7 @@ def snoop(handler, protocol=None):
                     else:
                         continue
                 handler(peerbymacaddress[mac])
-        except Exception as e:
+        except Exception:
             raise
 
 
@@ -645,7 +645,6 @@ def scan(srvtypes=_slp_services, addresses=None, localonly=False):
 # use ip neigh for the moment
 
 import subprocess
-import os
 
 neightable = {}
 neightime = 0
@@ -710,11 +709,9 @@ def refresh_neigh():
 import base64
 import hashlib
 import netifaces
-import os
 import re
 import socket
 import ssl
-import struct
 
 def stringify(instr):
     # Normalize unicode and bytes to 'str', correcting for

--- a/misc/ssdpscan.py
+++ b/misc/ssdpscan.py
@@ -2,7 +2,6 @@
 from select import select
 import socket
 import sys
-import socket
 
 def scan_nicname(nicname):
     idx = int(open('/sys/class/net/{}/ifindex'.format(nicname)).read())
@@ -10,7 +9,6 @@ def scan_nicname(nicname):
 
 def scan_nic(nicidx):
     known_peers = {}
-    srvs = {}
     s6 = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
     s6.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
     s6.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)


### PR DESCRIPTION
In preparation for CI pipeline.

Apply ruff's safe autofixes.
The changes are mechanical and behaviour-preserving. Issues fixed:

- F401: remove unused imports.
- F841: drop unused local variables and assignments, including discarded await/return values, unused "except ... as e" bindings, and unused "with ... as name" targets.
- F541: remove the f prefix from f-strings that contain no placeholders.
- E711: compare against None with "is"/"is not" instead of "=="/"!=".
- E712: test truthiness directly instead of comparing to True.
- E713: use "x not in y" instead of "not x in y".
- E714: use "is not" instead of "not ... is".
- E731: convert lambdas bound to a name into def statements.
- W291/W293: trim trailing whitespace on touched lines.