### PR TITLE
Increase net.core.rmem_max to 4 MB

### DIFF
--- a/confluent_server/sysctl/confluent.conf
+++ b/confluent_server/sysctl/confluent.conf
@@ -1,2 +1,2 @@
 # Increase available receive buffers for discovery scans
-net.core.rmem_max = 2097152
+net.core.rmem_max = 4194304


### PR DESCRIPTION
This was introduced 8 years ago. Newer OSs have 4194304 as default. Confluent shouldn't decrease the default.

```
RHEL 8           212992
RHEL 9          2097152
RHEL 10         2097152
Fedora 44       4194304

Ubuntu 24.04     212992
Ubuntu 26.06    4194304

SLES 15          212992
SLES 16          212992
```

It was changed to 4MB in upstream kernel, too:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a6d4f25888b83b8300aef28d9ee22765c1cc9b34