### PR TITLE
SELinux label diskless runtime files on EL

### DIFF
--- a/confluent_osdeploy/common/profile/scripts/functions
+++ b/confluent_osdeploy/common/profile/scripts/functions
@@ -108,6 +108,12 @@ run_remote_parts() {
     unset confluentscripttmpdir
 }
 
+set_selinux_context() {
+    if [ -x /usr/bin/chcon ]; then
+        /usr/bin/chcon "$1" "$2"
+    fi
+}
+
 source_remote() {
     set_confluent_vars
     unsettmpdir=0
@@ -150,9 +156,7 @@ run_remote() {
     if [ $? != 0 ]; then echo $requestedcmd failed to download; return 1; fi
     chmod +x $1
     cmd=$1
-    if [ -x /usr/bin/chcon ]; then
-        chcon system_u:object_r:bin_t:s0 $cmd
-    fi
+    set_selinux_context system_u:object_r:bin_t:s0 "$cmd"
     shift
     ./$cmd $*
     retcode=$?

--- a/confluent_osdeploy/el10-diskless/profiles/default/scripts/imageboot.sh
+++ b/confluent_osdeploy/el10-diskless/profiles/default/scripts/imageboot.sh
@@ -150,6 +150,9 @@ mkdir -p /sysroot/opt/confluent/bin
 curl -sf https://$confluent_whost/confluent-public/os/$confluent_profile/scripts/onboot.sh > /sysroot/opt/confluent/bin/onboot.sh
 chmod +x /sysroot/opt/confluent/bin/onboot.sh
 cp /opt/confluent/bin/apiclient /sysroot/opt/confluent/bin
+set_selinux_context system_u:object_r:systemd_unit_file_t:s0 /sysroot/etc/systemd/system/onboot.service
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/onboot.sh
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/apiclient
 ln -s /etc/systemd/system/onboot.service /sysroot/etc/systemd/system/multi-user.target.wants/onboot.service
 cp /etc/confluent/functions /sysroot/etc/confluent/functions
 if grep installtodisk /proc/cmdline > /dev/null; then

--- a/confluent_osdeploy/el7-diskless/profiles/default/scripts/imageboot.sh
+++ b/confluent_osdeploy/el7-diskless/profiles/default/scripts/imageboot.sh
@@ -116,6 +116,9 @@ mkdir -p /sysroot/opt/confluent/bin
 curl -sf https://$confluent_mgr/confluent-public/os/$confluent_profile/scripts/onboot.sh > /sysroot/opt/confluent/bin/onboot.sh
 chmod +x /sysroot/opt/confluent/bin/onboot.sh
 cp /opt/confluent/bin/apiclient /sysroot/opt/confluent/bin
+set_selinux_context system_u:object_r:systemd_unit_file_t:s0 /sysroot/etc/systemd/system/onboot.service
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/onboot.sh
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/apiclient
 ln -s /etc/systemd/system/onboot.service /sysroot/etc/systemd/system/multi-user.target.wants/onboot.service
 cp /etc/confluent/functions /sysroot/etc/confluent/functions
 if grep installtodisk /proc/cmdline > /dev/null; then

--- a/confluent_osdeploy/el8-diskless/profiles/default/scripts/imageboot.sh
+++ b/confluent_osdeploy/el8-diskless/profiles/default/scripts/imageboot.sh
@@ -120,6 +120,9 @@ mkdir -p /sysroot/opt/confluent/bin
 curl -sf https://$confluent_whost/confluent-public/os/$confluent_profile/scripts/onboot.sh > /sysroot/opt/confluent/bin/onboot.sh
 chmod +x /sysroot/opt/confluent/bin/onboot.sh
 cp /opt/confluent/bin/apiclient /sysroot/opt/confluent/bin
+set_selinux_context system_u:object_r:systemd_unit_file_t:s0 /sysroot/etc/systemd/system/onboot.service
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/onboot.sh
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/apiclient
 ln -s /etc/systemd/system/onboot.service /sysroot/etc/systemd/system/multi-user.target.wants/onboot.service
 cp /etc/confluent/functions /sysroot/etc/confluent/functions
 if grep installtodisk /proc/cmdline > /dev/null; then

--- a/confluent_osdeploy/el9-diskless/profiles/default/scripts/imageboot.sh
+++ b/confluent_osdeploy/el9-diskless/profiles/default/scripts/imageboot.sh
@@ -153,6 +153,9 @@ mkdir -p /sysroot/opt/confluent/bin
 curl -sf https://$confluent_whost/confluent-public/os/$confluent_profile/scripts/onboot.sh > /sysroot/opt/confluent/bin/onboot.sh
 chmod +x /sysroot/opt/confluent/bin/onboot.sh
 cp /opt/confluent/bin/apiclient /sysroot/opt/confluent/bin
+set_selinux_context system_u:object_r:systemd_unit_file_t:s0 /sysroot/etc/systemd/system/onboot.service
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/onboot.sh
+set_selinux_context system_u:object_r:bin_t:s0 /sysroot/opt/confluent/bin/apiclient
 ln -s /etc/systemd/system/onboot.service /sysroot/etc/systemd/system/multi-user.target.wants/onboot.service
 cp /etc/confluent/functions /sysroot/etc/confluent/functions
 if grep installtodisk /proc/cmdline > /dev/null; then

--- a/imgutil/el10/dracut/install
+++ b/imgutil/el10/dracut/install
@@ -13,7 +13,7 @@ dracut_install du df ssh-keygen scp
 dracut_install /lib64/libnss_dns*
 dracut_install /usr/lib64/libnl-3.so.200
 dracut_install /etc/nsswitch.conf /etc/services /etc/protocols
-dracut_install chmod whoami head tail basename tr
+dracut_install chmod chcon whoami head tail basename tr
 dracut_install /usr/sbin/arping dhcpcd logger hostnamectl
 inst /bin/bash /bin/sh
 dracut_install /lib64/libfuse.so.2

--- a/imgutil/el7/dracut/install
+++ b/imgutil/el7/dracut/install
@@ -14,7 +14,7 @@ dracut_install du df ssh-keygen scp clear dhclient
 dracut_install /lib64/libnss_dns.so.2
 dracut_install /usr/lib64/libnl-3.so.200
 dracut_install /etc/nsswitch.conf /etc/services /etc/protocols
-dracut_install chmod whoami head tail basename tr
+dracut_install chmod chcon whoami head tail basename tr
 dracut_install /usr/sbin/arping /usr/sbin/dhclient-script ipcalc logger hostnamectl
 inst /bin/bash /bin/sh
 dracut_install /lib64/libfuse.so.2
@@ -33,4 +33,3 @@ inst /usr/lib/dracut/modules.d/40network/net-lib.sh /lib/net-lib.sh
 # network mount, and disk imaging helpers can come from a second stage
 # this is narrowly focused on getting network up and fetching images
 # and those images may opt to do something with cloning or whatever
-

--- a/imgutil/el8/dracut/install
+++ b/imgutil/el8/dracut/install
@@ -12,7 +12,7 @@ dracut_install du df ssh-keygen scp clear dhclient
 dracut_install /lib64/libnss_dns-2.28.so /lib64/libnss_dns.so.2
 dracut_install /usr/lib64/libnl-3.so.200
 dracut_install /etc/nsswitch.conf /etc/services /etc/protocols
-dracut_install chmod whoami head tail basename tr
+dracut_install chmod chcon whoami head tail basename tr
 dracut_install /usr/sbin/arping /usr/sbin/dhclient-script ipcalc logger hostnamectl
 inst /bin/bash /bin/sh
 dracut_install /lib64/libfuse.so.2 /lib64/libfuse.so.2.9.7
@@ -31,4 +31,3 @@ inst /usr/lib/dracut/modules.d/40network/net-lib.sh /lib/net-lib.sh
 # network mount, and disk imaging helpers can come from a second stage
 # this is narrowly focused on getting network up and fetching images
 # and those images may opt to do something with cloning or whatever
-

--- a/imgutil/el9/dracut/install
+++ b/imgutil/el9/dracut/install
@@ -12,7 +12,7 @@ dracut_install du df ssh-keygen scp dhclient
 dracut_install /lib64/libnss_dns*
 dracut_install /usr/lib64/libnl-3.so.200
 dracut_install /etc/nsswitch.conf /etc/services /etc/protocols
-dracut_install chmod whoami head tail basename tr
+dracut_install chmod chcon whoami head tail basename tr
 dracut_install /usr/sbin/arping /usr/sbin/dhclient-script ipcalc logger hostnamectl
 inst /bin/bash /bin/sh
 dracut_install /lib64/libfuse.so.2


### PR DESCRIPTION
Centralize the SELinux chcon helper and use it for downloaded systemd units, onboot hooks, and apiclient files across EL7 through EL10. Include chcon in captured EL initramfs images.

Without this fix the onboot services failed to start on SELinux enabled captured image.