### PR TITLE
Skip add_local_repositories if no imgutil build --source is set

### DIFF
--- a/confluent_osdeploy/el8-diskless/profiles/default/scripts/add_local_repositories
+++ b/confluent_osdeploy/el8-diskless/profiles/default/scripts/add_local_repositories
@@ -28,6 +28,19 @@ if v4cfg == 'static' or v4cfg =='dhcp':
 if not server:
     server = '[{}]'.format(server6)
 
+try:
+    with open('/etc/confluentimg.buildinfo') as buildinfo:
+        if not any(line.startswith('BUILDSRC=') for line in buildinfo):
+            # image was built from the build system repositories (imgutil
+            # build without --source), so no distribution tree exists on
+            # the deployment server
+            sys.stdout.write('Image was built from the build system '
+                             'repositories, no local distribution to add, '
+                             'skipping\n')
+            sys.exit(0)
+except IOError:
+    pass
+
 path = '/confluent-public/os/{0}/distribution/'.format(profile)
 clnt = apiclient.HTTPSClient()
 cfgdata = clnt.grab_url(path + '.treeinfo').decode()

--- a/confluent_osdeploy/el9-diskless/profiles/default/scripts/add_local_repositories
+++ b/confluent_osdeploy/el9-diskless/profiles/default/scripts/add_local_repositories
@@ -32,6 +32,19 @@ if v4cfg == 'static' or v4cfg =='dhcp':
 if not server:
     server = '[{}]'.format(server6)
 
+try:
+    with open('/etc/confluentimg.buildinfo') as buildinfo:
+        if not any(line.startswith('BUILDSRC=') for line in buildinfo):
+            # image was built from the build system repositories (imgutil
+            # build without --source), so no distribution tree exists on
+            # the deployment server
+            sys.stdout.write('Image was built from the build system '
+                             'repositories, no local distribution to add, '
+                             'skipping\n')
+            sys.exit(0)
+except IOError:
+    pass
+
 path = '/confluent-public/os/{0}/distribution/'.format(profile)
 clnt = apiclient.HTTPSClient()
 cfgdata = clnt.grab_url(path + '.treeinfo').decode()


### PR DESCRIPTION
`BUILDSRC` is only set if imgutil build is run with `--source`, otherwise the build host repos are used. If `--source` is not used, there is no distribution symlink and `add_local_repositores` failed with 404. Check if `BUILDSRC` is set and skip `add_local_repositories` if this is the case.