### PR TITLE
Report stateless boot completion via new 'booted' status

### DIFF
--- a/confluent_osdeploy/el7-diskless/profiles/default/scripts/onboot.sh
+++ b/confluent_osdeploy/el7-diskless/profiles/default/scripts/onboot.sh
@@ -49,5 +49,5 @@ run_remote_parts onboot.d
 # Induce execution of remote configuration, e.g. ansible plays in ansible/onboot.d/
 run_remote_config onboot.d
 
-#curl -X POST -d 'status: booted' -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
+printf 'state: booted\nstatus: booted' | curl -X POST --data-binary @- -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
 kill $logshowpid

--- a/confluent_osdeploy/el8-diskless/profiles/default/scripts/onboot.sh
+++ b/confluent_osdeploy/el8-diskless/profiles/default/scripts/onboot.sh
@@ -70,5 +70,5 @@ if [ -f /run/confluent/onboot_sleep.pid ]; then
     kill "$sleeppid"
     rm -f /run/confluent/onboot_sleep.pid
 fi
-#curl -X POST -d 'status: booted' -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
+printf 'state: booted\nstatus: booted' | curl -X POST --data-binary @- -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
 kill $logshowpid

--- a/confluent_osdeploy/el9-diskless/profiles/default/scripts/onboot.sh
+++ b/confluent_osdeploy/el9-diskless/profiles/default/scripts/onboot.sh
@@ -65,5 +65,5 @@ if [ -f /run/confluent/onboot_sleep.pid ]; then
     rm -f /run/confluent/onboot_sleep.pid
 fi
 
-#curl -X POST -d 'status: booted' -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
+printf 'state: booted\nstatus: booted' | curl -X POST --data-binary @- -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
 kill $logshowpid

--- a/confluent_osdeploy/suse15-diskless/profiles/default/scripts/onboot.sh
+++ b/confluent_osdeploy/suse15-diskless/profiles/default/scripts/onboot.sh
@@ -29,5 +29,5 @@ run_remote_parts onboot.d
 # Induce execution of remote configuration, e.g. ansible plays in ansible/onboot.d/
 run_remote_config onboot.d
 
-#curl -X POST -d 'status: booted' -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
+printf 'state: booted\nstatus: booted' | curl -X POST --data-binary @- -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
 kill $logshowpid

--- a/confluent_osdeploy/ubuntu20.04-diskless/profiles/default/scripts/onboot.sh
+++ b/confluent_osdeploy/ubuntu20.04-diskless/profiles/default/scripts/onboot.sh
@@ -36,5 +36,5 @@ run_remote_parts onboot.d
 # Induce execution of remote configuration, e.g. ansible plays in ansible/onboot.d/
 run_remote_config onboot.d
 
-#curl -X POST -d 'status: booted' -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
+printf 'state: booted\nstatus: booted' | curl -X POST --data-binary @- -H "CONFLUENT_NODENAME: $nodename" -H "CONFLUENT_APIKEY: $confluent_apikey" https://$confluent_mgr/confluent-api/self/updatestatus
 kill $logshowpid

--- a/confluent_server/confluent/selfservice.py
+++ b/confluent_server/confluent/selfservice.py
@@ -480,10 +480,17 @@ async def handle_request(req, make_response, mimetype):
             mrsp = await make_response(mimetype, 200, 'Ok')
             await mrsp.write(b'Accepted')
             return
+        stayarmed = False
         if update['status'] == 'staged':
             targattr = 'deployment.stagedprofile'
         elif update['status'] == 'complete':
             targattr = 'deployment.profile'
+        elif update['status'] == 'booted':
+            # a stateless node reporting a successful boot; record the booted
+            # profile as current, but leave pendingprofile armed since the
+            # node needs it to network boot the same image on next boot
+            targattr = 'deployment.profile'
+            stayarmed = True
         else:
             raise Exception('Unknown update status request')
         currattr = cfg.get_node_attributes(nodename, 'deployment.*').get(
@@ -495,17 +502,19 @@ async def handle_request(req, make_response, mimetype):
             pending = currattr.get('deployment.pendingprofile', {}).get('value', '')
         updates = {}
         if pending:
-            updates['deployment.pendingprofile'] = {'value': ''}
-            if targattr == 'deployment.profile':
-                updates['deployment.stagedprofile'] = {'value': ''}
-                dls = cfg.get_node_attributes(nodename, 'deployment.lock')
-                dls = dls.get(nodename, {}).get('deployment.lock', {}).get('value', None)
-                if dls == 'autolock':
-                    updates['deployment.lock'] = 'locked'
+            if not stayarmed:
+                updates['deployment.pendingprofile'] = {'value': ''}
+                if targattr == 'deployment.profile':
+                    updates['deployment.stagedprofile'] = {'value': ''}
+                    dls = cfg.get_node_attributes(nodename, 'deployment.lock')
+                    dls = dls.get(nodename, {}).get('deployment.lock', {}).get('value', None)
+                    if dls == 'autolock':
+                        updates['deployment.lock'] = 'locked'
             currprof = currattr.get(targattr, {}).get('value', '')
             if currprof != pending:
                 updates[targattr] = {'value': pending}
-            await cfg.set_node_attributes({nodename: updates})
+            if updates:
+                await cfg.set_node_attributes({nodename: updates})
             return await make_response('text/plain', 200, 'OK', body='OK')
         else:
             return await make_response('text/plain', 500, 'Error', body='No pending profile detected, unable to accept status update')


### PR DESCRIPTION
Diskless profiles had the updatestatus callback in onboot.sh commented out because no suitable status existed: 'complete' clears deployment.pendingprofile, which the PXE responder requires to answer the next network boot of a diskless node.

Add a 'booted' status that records the pending profile as deployment.profile while leaving pendingprofile armed and skipping autolock, and enable the onboot.sh callback in all diskless profiles. nodedeploy now shows 'pending: <profile> (booted)' for a running stateless node.

Tested in a VM setup:

```
[root@confluent-alma10 ~]# nodeattrib c1 deployment
c1: deployment.apiarmed: continuous
c1: deployment.client_ip: 172.30.2.1
c1: deployment.encryptboot:
c1: deployment.lock:
c1: deployment.pendingprofile: alma-10.2-x86_64-diskless
c1: deployment.profile:
c1: deployment.sealedapikey:
c1: deployment.stagedprofile:
c1: deployment.state:
c1: deployment.state_detail:
c1: deployment.useinsecureprotocols: firmware
[root@confluent-alma10 ~]# nodepower c1 boot
[root@confluent-alma10 ~]# nodeattrib c1 deployment
c1: deployment.apiarmed: continuous
c1: deployment.client_ip: 172.30.2.10
c1: deployment.encryptboot:
c1: deployment.lock:
c1: deployment.pendingprofile: alma-10.2-x86_64-diskless  # retained for next network boot
c1: deployment.profile: alma-10.2-x86_64-diskless         # recorded by new 'booted' status
c1: deployment.sealedapikey:
c1: deployment.stagedprofile:
c1: deployment.state: booted                              # state for nodedeploy output
c1: deployment.state_detail:
c1: deployment.useinsecureprotocols: firmware
[root@confluent-alma10 ~]# nodedeploy c1
c1: pending: alma-10.2-x86_64-diskless (booted)
[root@confluent-alma10 ~]# nodedeploy -n -p c1 alma-10.2-x86_64-diskless
[root@confluent-alma10 ~]# nodeattrib c1 deployment
c1: deployment.apiarmed: continuous
c1: deployment.client_ip: 172.30.2.10
c1: deployment.encryptboot:
c1: deployment.lock:
c1: deployment.pendingprofile: alma-10.2-x86_64-diskless  # set by nodedeploy
c1: deployment.profile:                                   # cleared by nodedeploy
c1: deployment.sealedapikey:
c1: deployment.stagedprofile:
c1: deployment.state:                                     # cleared by nodedeploy
c1: deployment.state_detail:
c1: deployment.useinsecureprotocols: firmware
```