### PR TITLE
Validate nodeattrib IPs and MACs

### DIFF
--- a/confluent_server/confluent/config/attributes.py
+++ b/confluent_server/confluent/config/attributes.py
@@ -80,6 +80,65 @@
 #    },
 #}
 
+import re
+import socket
+
+
+def _validate_ipaddress(family, famname, val, allowprefix):
+    addr = val
+    if '/' in val:
+        if not allowprefix:
+            raise ValueError(
+                '"{0}" must be a plain {1} address without a '
+                '/prefix'.format(val, famname))
+        addr, prefix = val.split('/', 1)
+        try:
+            prefix = int(prefix)
+        except ValueError:
+            prefix = -1
+        maxprefix = 32 if family == socket.AF_INET else 128
+        if not 0 <= prefix <= maxprefix:
+            raise ValueError(
+                '"{0}" has an invalid prefix length'.format(val))
+    try:
+        socket.inet_pton(family, addr)
+    except OSError:
+        raise ValueError(
+            '"{0}" is not a valid {1} address'.format(val, famname))
+
+
+def validate_ipv4_address(val):
+    _validate_ipaddress(socket.AF_INET, 'IPv4', val, True)
+
+
+def validate_ipv4_gateway(val):
+    _validate_ipaddress(socket.AF_INET, 'IPv4', val, False)
+
+
+def validate_ipv6_address(val):
+    _validate_ipaddress(socket.AF_INET6, 'IPv6', val, True)
+
+
+def validate_ipv6_gateway(val):
+    _validate_ipaddress(socket.AF_INET6, 'IPv6', val, False)
+
+
+_hwaddr_pattern = re.compile(r'^[0-9a-f]{2}(:[0-9a-f]{2})+$')
+
+
+def validate_hwaddr(val):
+    normval = val.lower().replace('-', ':')
+    if not _hwaddr_pattern.match(normval):
+        raise ValueError(
+            '"{0}" is not a valid hardware address (expected colon or '
+            'hyphen delimited hex octets)'.format(val))
+    octets = normval.count(':') + 1
+    if octets not in (6, 8, 20):
+        raise ValueError(
+            '"{0}" has {1} octets, expected 6 (Ethernet), 8 (EUI-64) or '
+            '20 (InfiniBand)'.format(val, octets))
+
+
 user = {
     'password': {
         'description':  'The passphrase used to authenticate this user'
@@ -507,6 +566,7 @@ node = {
                        'Specify the parent device using net.interface_names.'
     },
     'net.ipv4_address': {
+        'validate': validate_ipv4_address,
         'description': 'When configuring static, use this address.  If '
                        'unspecified, it will check if the node name resolves '
                        'to an IP address.  Additionally, the subnet prefix '
@@ -524,11 +584,13 @@ node = {
         'validvalues': ('dhcp', 'static', 'firmwaredhcp', 'firmwarenone', 'none')
     },
     'net.ipv4_gateway': {
+        'validate': validate_ipv4_gateway,
         'description':  'The IPv4 gateway to use if applicable.  As is the '
                         'case for other net attributes, net.eth0.ipv4_gateway '
                         'and similar is accepted.'
     },
     'net.ipv6_address': {
+        'validate': validate_ipv6_address,
         'description': 'When configuring static, use this address.  If '
                        'unspecified, it will check if the node name resolves '
                        'to an IP address.  Additionally, the subnet prefix '
@@ -546,11 +608,13 @@ node = {
         'validvalues': ('dhcp', 'static', 'firmwaredhcp', 'firmwarenone', 'none')
     },
     'net.ipv6_gateway': {
+        'validate': validate_ipv6_gateway,
         'description':  'The IPv6 gateway to use if applicable.  As is the '
                         'case for other net attributes, net.eth0.ipv6_gateway '
                         'and similar is accepted.'
     },
     'net.hwaddr': {
+        'validate': validate_hwaddr,
         'description': 'The hardware address, aka MAC address of the interface indicated, generally populated by the '
                        'PXE discovery mechanism'
     },

--- a/confluent_server/confluent/config/configmanager.py
+++ b/confluent_server/confluent/config/configmanager.py
@@ -550,6 +550,26 @@ def attribute_is_invalid(attrname, attrval):
     return False
 
 
+def validate_attribute_value(attrname, attrval, owner):
+    # Apply any format validator declared for the attribute in the
+    # attribute schema, raising ValueError for a malformed value.
+    # Expression values are deferred and not evaluated here.
+    validator = allattributes.node.get(
+        _get_valid_attrname(attrname), {}).get('validate')
+    if not validator:
+        return
+    if isinstance(attrval, dict):
+        if 'expression' in attrval:
+            return
+        attrval = attrval.get('value', None)
+    if not attrval or not isinstance(attrval, str):
+        return
+    try:
+        validator(attrval)
+    except ValueError as e:
+        raise ValueError('{0} on {1}: {2}'.format(attrname, owner, e))
+
+
 def _get_valid_attrname(attrname):
     if attrname.startswith('net.') or attrname.startswith('power.'):
         # For net.* attribtues, split on the dots and put back together
@@ -2075,6 +2095,8 @@ class ConfigManager(object):
                     if attribute_is_invalid(attr, attrval):
                         errstr = "{0} attribute is invalid".format(attr)
                         raise ValueError(errstr)
+                    validate_attribute_value(attr, attrval,
+                                             'group {0}'.format(group))
                     attribmap[group][attr] = attrval
                 if attr == 'nodes':
                     if isinstance(attribmap[group][attr], dict):
@@ -2600,6 +2622,8 @@ class ConfigManager(object):
                         errstr = "{0} attribute on node {1} is invalid".format(
                             attrname, node)
                         raise ValueError(errstr)
+                    validate_attribute_value(attrname, attrval,
+                                             'node {0}'.format(node))
                     attribmap[node][attrname] = attrval
         for node in confluent.util.natural_sort(attribmap):
             node = confluent.util.stringify(node)

--- a/confluent_server/confluent/config/configmanager.py
+++ b/confluent_server/confluent/config/configmanager.py
@@ -1900,6 +1900,30 @@ class ConfigManager(object):
             fmt = _ExpressionFormat(cfgobj, node)
             yield (node, fmt.format(expression))
 
+    def _validate_attrib_expression(self, attrname, expression, node, owner):
+        # Best-effort format check of an expression value: evaluate it
+        # against the current configuration and apply any format validator
+        # declared for the attribute to the result.  An expression that
+        # cannot be evaluated yet (e.g. the node is still being created, or
+        # it depends on an attribute not yet set) is let through; only a
+        # cleanly evaluated but malformed result is rejected.
+        validator = allattributes.node.get(
+            _get_valid_attrname(attrname), {}).get('validate')
+        if not validator:
+            return
+        try:
+            value = next(self.expand_attrib_expression([node], expression))[1]
+        except Exception:
+            return
+        if not value or not isinstance(value, str):
+            return
+        try:
+            validator(value)
+        except ValueError as e:
+            raise ValueError(
+                '{0} expression "{1}" on {2} evaluates to an invalid '
+                'value: {3}'.format(attrname, expression, owner, e))
+
     def get_node_attributes(self, nodelist, attributes=(), decrypt=None):
         if decrypt is None:
             decrypt = self.decrypt
@@ -2097,6 +2121,12 @@ class ConfigManager(object):
                         raise ValueError(errstr)
                     validate_attribute_value(attr, attrval,
                                              'group {0}'.format(group))
+                    if isinstance(attrval, dict) and 'expression' in attrval:
+                        for member in self._cfgstore['nodegroups'].get(
+                                group, {}).get('nodes', []):
+                            self._validate_attrib_expression(
+                                attr, attrval['expression'], member,
+                                'group {0} member {1}'.format(group, member))
                     attribmap[group][attr] = attrval
                 if attr == 'nodes':
                     if isinstance(attribmap[group][attr], dict):
@@ -2624,6 +2654,10 @@ class ConfigManager(object):
                         raise ValueError(errstr)
                     validate_attribute_value(attrname, attrval,
                                              'node {0}'.format(node))
+                    if isinstance(attrval, dict) and 'expression' in attrval:
+                        self._validate_attrib_expression(
+                            attrname, attrval['expression'], node,
+                            'node {0}'.format(node))
                     attribmap[node][attrname] = attrval
         for node in confluent.util.natural_sort(attribmap):
             node = confluent.util.stringify(node)


### PR DESCRIPTION
This is just a POC for now.
It validates nodeattrib `net.hwaddr`, `net.ipv4_address`, `net.ipv6_address`, `net.ipv4_gateway`, `net.ipv6_gateway`.
nodeattribexpressions are validated with a best effort approach.

Not sure this will ever be useful but it might be a good starting point for some discussion about additional attribute validation.

Some examples:

```console
[root@confluent-alma10 ~]# # MAC validation
[root@confluent-alma10 ~]# nodeattrib c1 net.test.hwaddr=123
Error: Bad Request - net.test.hwaddr on node c1: "123" is not a valid hardware address (expected colon or hyphen delimited hex octets)
[root@confluent-alma10 ~]# nodeattrib c1 net.test.hwaddr=12:23:34
Error: Bad Request - net.test.hwaddr on node c1: "12:23:34" has 3 octets, expected 6 (Ethernet), 8 (EUI-64) or 20 (InfiniBand)
[root@confluent-alma10 ~]# nodeattrib c1 net.test.hwaddr=12:23:34:45:65:944
Error: Bad Request - net.test.hwaddr on node c1: "12:23:34:45:65:944" is not a valid hardware address (expected colon or hyphen delimited hex octets)
[root@confluent-alma10 ~]# nodeattrib c1 net.test.hwaddr=12:23:34:45:65:94
c1: 12:23:34:45:65:94

[root@confluent-alma10 ~]# # IP validation
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_address=123.300.100.100
Error: Bad Request - net.test.ipv4_address on node c1: "123.300.100.100" is not a valid IPv4 address
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_address=123.255.100.100
c1: 123.255.100.100
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_address=123.255.100.100/10
c1: 123.255.100.100/10
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_address=123.255.100.100/100
Error: Bad Request - net.test.ipv4_address on node c1: "123.255.100.100/100" has an invalid prefix length

[root@confluent-alma10 ~]# # IP gateway validation
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_gateway=1.2.3.4/24
Error: Bad Request - net.test.ipv4_gateway on node c1: "1.2.3.4/24" must be a plain IPv4 address without a /prefix
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_gateway=1.2.3.4
c1: 1.2.3.4
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_gateway=1.2.3.400
Error: Bad Request - net.test.ipv4_gateway on node c1: "1.2.3.400" is not a valid IPv4 address

[root@confluent-alma10 ~]# # nodeattribexpression best-effort examples
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_address=192.168.0.{n1}
c1: 192.168.0.1
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_address=192.168.0.{n1+300}
Error: Bad Request - net.test.ipv4_address expression "192.168.0.{n1+300}" on node c1 evaluates to an invalid value: "192.168.0.301" is not a valid IPv4 address
[root@confluent-alma10 ~]# nodeattrib c1 net.test.ipv4_address=192.168.0.{n1+200}
c1: 192.168.0.201
[root@confluent-alma10 ~]# nodegroupdefine test
test: created
[root@confluent-alma10 ~]# nodedefine c200 groups=test
c200: created
[root@confluent-alma10 ~]# nodegroupattrib test net.ipv4_address=192.168.0.{n1}
[root@confluent-alma10 ~]# nodeattrib c200 net.ipv4_address
c200: net.ipv4_address: 192.168.0.200
[root@confluent-alma10 ~]# nodedefine c300 groups=test # validation doesn't work when new nodes create invalid IPs
c300: created
[root@confluent-alma10 ~]# nodeattrib c300 net.ipv4_address
c300: net.ipv4_address: 192.168.0.300
```