### PR TITLE
Fix async-port regressions in confluent_client

### DIFF
--- a/confluent_client/bin/nodeconsole
+++ b/confluent_client/bin/nodeconsole
@@ -910,7 +910,7 @@ async def do_screenshot():
             dorefresh = False
         else:
             dorefresh = True
-            time.sleep(options.interval)
+            await asyncio.sleep(options.interval)
     sys.exit(0)
 
 async def grab_vncs(urlbynode):

--- a/confluent_client/bin/nodediscover
+++ b/confluent_client/bin/nodediscover
@@ -53,6 +53,7 @@ columnmapping = {
 async def register_endpoint(options, session, addr):
     neednewline = False
     current = 0
+    total = 0
     async for rsp in session.update('/discovery/register', {'addresses': addr}):
         if 'count' in rsp:
             total = rsp['count']

--- a/confluent_client/bin/nodediscover
+++ b/confluent_client/bin/nodediscover
@@ -20,7 +20,6 @@ import csv
 import optparse
 import os
 import sys
-import time
 
 path = os.path.dirname(os.path.realpath(__file__))
 path = os.path.realpath(os.path.join(path, '..', 'lib', 'python'))
@@ -364,7 +363,7 @@ async def assign_discovery(options, session, needid=True):
 async def blocking_scan(session):
     list([x async for x in session.update('/discovery/rescan', {'rescan': 'start'})])
     while(list([x async for x in session.read('/discovery/rescan')])[0].get('scanning', False)):
-        time.sleep(0.5)
+        await asyncio.sleep(0.5)
     list([x async for x in session.update('/networking/macs/rescan', {'rescan': 'start'})])
 
 

--- a/confluent_client/bin/nodediscover
+++ b/confluent_client/bin/nodediscover
@@ -211,12 +211,12 @@ async def import_csv(options, session):
             alldata.append(nodedatum)
         allthere = True
         for nodedatum in alldata:
-            if not search_record(nodedatum, options, session) and not broken:
+            if not await search_record(nodedatum, options, session) and not broken:
                 allthere = False
                 await blocking_scan(session)
                 break
         for nodedatum in alldata:
-            if not allthere and not search_record(nodedatum, options, session):
+            if not allthere and not await search_record(nodedatum, options, session):
                 sys.stderr.write(
                     "Could not match the following data: " +
                     repr(nodedatum) + '\n')
@@ -224,11 +224,12 @@ async def import_csv(options, session):
             nodedata.append(nodedatum)
     if broken:
         sys.exit(1)
+    assignments = []
     for datum in nodedata:
-        maclist = search_record(datum, options, session)
+        maclist = await search_record(datum, options, session)
         datum = datum_to_attrib(datum)
         nodename = datum['name']
-        for res in session.create('/nodes/', datum):
+        async for res in session.create('/nodes/', datum):
             if 'error' in res:
                 sys.stderr.write(res['error'] + '\n')
                 exitcode |= res.get('errorcode', 1)
@@ -237,29 +238,28 @@ async def import_csv(options, session):
                 print('Defined ' + res['created'])
             else:
                 print(repr(res))
-        child = os.fork()
-        if child:
-            continue
-        for mac in maclist:
-            mysess = client.Command()
-            for res in mysess.update('/discovery/by-mac/{0}'.format(mac),
-                                      {'node': nodename}):
-                if 'error' in res:
-                    sys.stderr.write(res['error'] + '\n')
-                    exitcode |= res.get('errorcode', 1)
-                    continue
-                elif 'assigned' in res:
-                    print('Discovered ' + res['assigned'])
-                else:
-                    print(repr(res))
-        sys.exit(0)
-    while True:
-        try:
-            os.wait()
-        except ChildProcessError:
-            break
+        assignments.append(assign_macs(maclist, nodename))
+    for rcode in await asyncio.gather(*assignments):
+        exitcode |= rcode
     if exitcode:
         sys.exit(exitcode)
+
+
+async def assign_macs(maclist, nodename):
+    exitcode = 0
+    for mac in maclist:
+        mysess = client.Command()
+        async for res in mysess.update('/discovery/by-mac/{0}'.format(mac),
+                                       {'node': nodename}):
+            if 'error' in res:
+                sys.stderr.write(res['error'] + '\n')
+                exitcode |= res.get('errorcode', 1)
+                continue
+            elif 'assigned' in res:
+                print('Discovered ' + res['assigned'])
+            else:
+                print(repr(res))
+    return exitcode
 
 
 async def list_discovery(options, session):

--- a/confluent_client/bin/nodediscover
+++ b/confluent_client/bin/nodediscover
@@ -51,10 +51,10 @@ columnmapping = {
 }
 #TODO: add chassis uuid
 
-def register_endpoint(options, session, addr):
+async def register_endpoint(options, session, addr):
     neednewline = False
     current = 0
-    for rsp in session.update('/discovery/register', {'addresses': addr}):
+    async for rsp in session.update('/discovery/register', {'addresses': addr}):
         if 'count' in rsp:
             total = rsp['count']
         elif total > 1:
@@ -70,15 +70,15 @@ def register_endpoint(options, session, addr):
     if neednewline:
         print('')
 
-def subscribe_discovery(options, session, subscribe, targ):
+async def subscribe_discovery(options, session, subscribe, targ):
     keyn = 'subscribe' if subscribe else 'unsubscribe'
     payload = {keyn: targ}
     if subscribe:
-        for rsp in session.update('/discovery/subscriptions/{0}'.format(targ), payload):
+        async for rsp in session.update('/discovery/subscriptions/{0}'.format(targ), payload):
             if 'status' in rsp:
                 print(rsp['status'])
     else:
-        for rsp in session.delete('/discovery/subscriptions/{0}'.format(targ)):
+        async for rsp in session.delete('/discovery/subscriptions/{0}'.format(targ)):
             if 'status' in rsp:
                 print(rsp['status'])
     
@@ -427,11 +427,11 @@ async def main():
     if args[0] == 'reassign':
         await assign_discovery(options, session, False)
     if args[0] == 'register':
-        register_endpoint(options, session, args[1])
+        await register_endpoint(options, session, args[1])
     if args[0] == 'subscribe':
-        subscribe_discovery(options, session, True, args[1])
+        await subscribe_discovery(options, session, True, args[1])
     if args[0] == 'unsubscribe':
-        subscribe_discovery(options, session, False, args[1])
+        await subscribe_discovery(options, session, False, args[1])
     if args[0] == 'rescan':
         await blocking_scan(session)
         print("Rescan complete")

--- a/confluent_client/bin/nodediscover
+++ b/confluent_client/bin/nodediscover
@@ -242,8 +242,12 @@ async def import_csv(options, session):
                 print('Defined ' + res['created'])
             else:
                 print(repr(res))
-        assignments.append(assign_macs(maclist, nodename, assignlimit))
-    for rcode in await asyncio.gather(*assignments):
+        assignments.append(
+            asyncio.create_task(assign_macs(maclist, nodename, assignlimit)))
+    for rcode in await asyncio.gather(*assignments, return_exceptions=True):
+        if isinstance(rcode, BaseException):
+            sys.stderr.write('Error assigning discovery data: {0}\n'.format(rcode))
+            rcode = 1
         exitcode |= rcode
     if exitcode:
         sys.exit(exitcode)

--- a/confluent_client/bin/nodediscover
+++ b/confluent_client/bin/nodediscover
@@ -180,6 +180,9 @@ def datum_to_attrib(datum):
 
 unique_fields = frozenset(['serial', 'mac', 'uuid'])
 
+# Cap how many nodes hold a discovery session at once while importing
+maxconcurrentassign = 128
+
 async def import_csv(options, session):
     nodedata = []
     unique_data = {}
@@ -225,6 +228,7 @@ async def import_csv(options, session):
     if broken:
         sys.exit(1)
     assignments = []
+    assignlimit = asyncio.Semaphore(maxconcurrentassign)
     for datum in nodedata:
         maclist = await search_record(datum, options, session)
         datum = datum_to_attrib(datum)
@@ -238,27 +242,30 @@ async def import_csv(options, session):
                 print('Defined ' + res['created'])
             else:
                 print(repr(res))
-        assignments.append(assign_macs(maclist, nodename))
+        assignments.append(assign_macs(maclist, nodename, assignlimit))
     for rcode in await asyncio.gather(*assignments):
         exitcode |= rcode
     if exitcode:
         sys.exit(exitcode)
 
 
-async def assign_macs(maclist, nodename):
+async def assign_macs(maclist, nodename, assignlimit):
     exitcode = 0
-    for mac in maclist:
+    async with assignlimit:
+        # A session of our own, since the connection carries one request at a
+        # time and the caller's is busy defining the remaining nodes
         mysess = client.Command()
-        async for res in mysess.update('/discovery/by-mac/{0}'.format(mac),
-                                       {'node': nodename}):
-            if 'error' in res:
-                sys.stderr.write(res['error'] + '\n')
-                exitcode |= res.get('errorcode', 1)
-                continue
-            elif 'assigned' in res:
-                print('Discovered ' + res['assigned'])
-            else:
-                print(repr(res))
+        for mac in maclist:
+            async for res in mysess.update('/discovery/by-mac/{0}'.format(mac),
+                                           {'node': nodename}):
+                if 'error' in res:
+                    sys.stderr.write(res['error'] + '\n')
+                    exitcode |= res.get('errorcode', 1)
+                    continue
+                elif 'assigned' in res:
+                    print('Discovered ' + res['assigned'])
+                else:
+                    print(repr(res))
     return exitcode
 
 

--- a/confluent_client/confluent/asynclient.py
+++ b/confluent_client/confluent/asynclient.py
@@ -347,12 +347,12 @@ class Command(object):
             else:
                 ikey = key
             if input is None:
-                for res in await self.read('/nodegroups/{0}/{1}'.format(
+                async for res in self.read('/nodegroups/{0}/{1}'.format(
                         noderange, resource)):
                     rc = self.handle_results(ikey, rc, res)
             else:
                 kwargs[ikey] = input
-                for res in await self.update('/nodegroups/{0}/{1}'.format(
+                async for res in self.update('/nodegroups/{0}/{1}'.format(
                         noderange, resource), kwargs):
                     rc = self.handle_results(ikey, rc, res)
             return rc
@@ -667,10 +667,10 @@ def show_attr(attr, requestargs, seenattributes, options, node):
     return processattr
 
 
-def printgroupattributes(session, requestargs, showtype, nodetype, noderange, options):
+async def printgroupattributes(session, requestargs, showtype, nodetype, noderange, options):
     exitcode = 0
     seenattributes = set([])
-    for res in session.read('/{0}/{1}/attributes/{2}'.format(nodetype, noderange, showtype)):
+    async for res in session.read('/{0}/{1}/attributes/{2}'.format(nodetype, noderange, showtype)):
         if 'error' in res:
             sys.stderr.write(res['error'] + '\n')
             exitcode = 1

--- a/confluent_client/confluent/asynclient.py
+++ b/confluent_client/confluent/asynclient.py
@@ -396,6 +396,7 @@ class Command(object):
         self.connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.connection.setsockopt(socket.SOL_SOCKET, SO_PASSCRED, 1)
         self.connection.connect(self.serverloc)
+        self.connection.setblocking(False)
 
     async def _connect_tls(self):
         server, port = _parseserver(self.serverloc)

--- a/confluent_client/confluent/asynctlvdata.py
+++ b/confluent_client/confluent/asynctlvdata.py
@@ -99,9 +99,9 @@ class ClientFile(object):
 
 
 
-def _sendmsg(loop, fut, sock, msg, fds, rfd):
-    if rfd is not None:
-        loop.remove_reader(rfd)
+def _sendmsg(loop, fut, sock, msg, fds, wfd):
+    if wfd is not None:
+        loop.remove_writer(wfd)
     if fut.cancelled():
         return
     try:
@@ -110,7 +110,7 @@ def _sendmsg(loop, fut, sock, msg, fds, rfd):
             [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))])
     except (BlockingIOError, InterruptedError):
         fd = sock.fileno()
-        loop.add_reader(fd, _sendmsg, loop, fut, sock, fd)
+        loop.add_writer(fd, _sendmsg, loop, fut, sock, msg, fds, fd)
     except Exception as exc:
         fut.set_exception(exc)
     else:
@@ -127,6 +127,8 @@ def send_fds(sock, msg, fds):
 def _recvmsg(loop, fut, sock, msglen, maxfds, rfd):
     if rfd is not None:
         loop.remove_reader(rfd)
+    if fut.cancelled():
+        return
     fds = array.array("i")   # Array of ints
     try:
         msg, ancdata, flags, addr = sock.recvmsg(


### PR DESCRIPTION
The asyncio port converted six client tools to `asyncio.run()` against the new `asynclient`/`asynctlvdata`, but a number of call sites were left with synchronous idioms, so some commands failed.

_Note: AI assisted_

## Fixes

- **`nodediscover register` / `subscribe` / `unsubscribe`** `register_endpoint()` and `subscribe_discovery()` were plain functions iterating the async client generators, so all three subcommands failed immediately with `TypeError: 'async_generator' object is not iterable`. `register_endpoint()` also primed `current` but never `total`, so a first response carrying no count ended in `UnboundLocalError`.
- **`nodediscover -i <csv> assign`** `search_record()` was called without `await` (the returned coroutine is always truthy, so the rescan on incomplete discovery data never happened), the node creation loop used plain `for`, and the per-node discovery assignment was `os.fork()`ed while the event loop was running. Assignments now run concurrently as tasks, which also lets their exit codes propagate: the forked child always ended in `sys.exit(0)`, discarding its errorcode. They are gathered with `return_exceptions=True`, so a connection dropping against one node is reported and counted rather than ending the batch with a traceback, and a semaphore caps how many nodes hold a session at once, since the fork fan-out was bounded by nothing. Each node now opens one session rather than one per MAC.
- **`asynctlvdata._sendmsg`** the `EAGAIN` retry registered `add_reader` for a blocked *write* and passed four of six required arguments, so the callback raised `TypeError` once it fired. `_recvmsg` also now skips its work if the future was cancelled while waiting, as `_sendmsg` already did. This module is imported by the server, so both paths are reached by the daemon whenever a descriptor is passed over the local socket.
- **Nodegroup attribute paths** `simple_nodegroups_command()` awaited the async generators returned by `read`/`update`, and `printgroupattributes()` was left synchronous. Not reachable yet (`nodegroupattrib` still uses the traditional client), but these are the paths it will use once ported.
- **Non-blocking local socket** `_connect_unix()` left the socket blocking while `_connect_tls()` sets a zero timeout, so every `loop.sock_recv`/`sock_sendall` ran inline and stalled the event loop. Most visible in `nodeconsole --video`, where a power action stopped the tiles refreshing until the BMC finished; under asyncio debug mode the client failed outright with `ValueError: the socket must be non-blocking`.
- **`time.sleep` in coroutines** `nodediscover`'s rescan poll and `nodeconsole`'s screenshot refresh blocked the loop, stalling the input handler and VNC streaming tasks.

## Testing

Exercised against a stub server speaking the same TLV handshake as `sockapi.sessionhdl()`: register/subscribe/unsubscribe succeed, CSV import defines and assigns concurrently, and a failing assignment now propagates its errorcode as the exit status.
Also verified against a live server (`nodediscover list`/`register`/`subscribe`,
CSV import reaching the unmatched-record report instead of crashing, plus `nodeattrib` and `nodelist` for regressions).

The later gather changes were checked by driving `import_csv()` with fake sessions: a 20 node import stays within the session cap, and with one node's connection dropping mid assignment the remaining seven of eight still complete, the failure is reported, and the exit status is 1.