### PR TITLE
Fix the NextScale SMM web path on the asyncio port

### DIFF
--- a/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
@@ -360,7 +360,7 @@ class OEMHandler(generic.OEMHandler):
             srvs.append(ntpres['data'][129:257].rstrip('\x00'))
             return srvs
         if await self.is_fpc():
-            return self.smmhandler.get_ntp_servers()
+            return await self.smmhandler.get_ntp_servers()
         if self.has_tsma:
             return await self.tsmahandler.get_ntp_servers()
         return ()
@@ -375,7 +375,7 @@ class OEMHandler(generic.OEMHandler):
                     netfn=0x32, command=0xa8, data=(3, 0), timeout=15)
             return True
         if await self.is_fpc():
-            self.smmhandler.set_ntp_enabled(enabled)
+            await self.smmhandler.set_ntp_enabled(enabled)
             return True
         if self.has_tsma:
             await self.tsmahandler.set_ntp_enabled(enabled)
@@ -393,7 +393,7 @@ class OEMHandler(generic.OEMHandler):
             if not 0 <= index <= 2:
                 raise pygexc.InvalidParameterValue(
                     'SMM supports indexes 0 through 2')
-            self.smmhandler.set_ntp_server(server, index)
+            await self.smmhandler.set_ntp_server(server, index)
             return True
         elif self.has_tsma:
             if not (0 <= index <= 1):
@@ -940,7 +940,7 @@ class OEMHandler(generic.OEMHandler):
                 name += rsp['data'][:]
             return name.rstrip('\x00')
         elif await self.is_fpc():
-            return self.smmhandler.get_domain()
+            return await self.smmhandler.get_domain()
 
     async def set_oem_domain_name(self, name):
         if await self.has_tsm():
@@ -959,20 +959,20 @@ class OEMHandler(generic.OEMHandler):
             await self._restart_dns()
             return
         elif await self.is_fpc():
-            self.smmhandler.set_domain(name)
+            await self.smmhandler.set_domain(name)
 
     async def set_hostname(self, hostname):
         if await self.has_xcc():
             return await self.immhandler.set_hostname(hostname)
         elif await self.is_fpc():
-            return self.smmhandler.set_hostname(hostname)
+            return await self.smmhandler.set_hostname(hostname)
         return await super(OEMHandler, self).set_hostname(hostname)
 
     async def get_hostname(self):
         if await self.has_xcc():
             return await self.immhandler.get_hostname()
         elif await self.is_fpc():
-            return self.smmhandler.get_hostname()
+            return await self.smmhandler.get_hostname()
         return await super(OEMHandler, self).get_hostname()
 
     """ Gets a remote console launcher for a Lenovo ThinkServer.

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -409,15 +409,15 @@ class SMMClient(object):
 
     async def get_bmc_configuration(self, variant):
         settings = {}
-        wc = self.wc
-        wc.request(
-            'POST', '/data',
+        wc = await self.wc()
+        rspbody, status, _ = await wc.grab_response_with_status(
+            '/data',
             ('get=passwordMinLength,passwordForceChange,passwordDurationDays,'
              'passwordExpireWarningDays,passwordChangeInterval,'
              'passwordReuseCheckNum,passwordFailAllowdNum,'
              'passwordLockoutTimePeriod,timeZone'))
-        rsp = wc.getresponse()
-        rspbody = rsp.read()
+        if status != 200:
+            raise Exception(rspbody)
         accountinfo = fromstring(rspbody)
         for rule in self.rulemap:
             ruleinfo = accountinfo.find(self.rulemap[rule])
@@ -693,9 +693,10 @@ class SMMClient(object):
                             changeset[key]['value']))
         if rules:
             rules = 'set={0}'.format(','.join(rules))
-            wc = self.wc
-            wc.request('POST', '/data', rules)
-            wc.getresponse().read()
+            wc = await self.wc()
+            rsp, status, _ = await wc.grab_response_with_status('/data', rules)
+            if status != 200:
+                raise Exception(rsp)
         if powercfg != [None, None]:
             if variant != 6:
                 if None in powercfg:
@@ -734,12 +735,12 @@ class SMMClient(object):
             username = bytes(rsp['data']).rstrip(b'\x00')
             if not isinstance(username, str):
                 username = username.decode('utf8')
-            wc = self.wc
-            wc.request(
-                'POST', '/data', 'set=user({0},1,{1},511,,4,15,0)'.format(
+            wc = await self.wc()
+            rsp, status, _ = await wc.grab_response_with_status(
+                '/data', 'set=user({0},1,{1},511,,4,15,0)'.format(
                     uid, username))
-            rsp = wc.getresponse()
-            rsp.read()
+            if status != 200:
+                raise Exception(rsp)
 
     async def reseat_bay(self, bay):
         bay = int(bay)
@@ -791,7 +792,7 @@ class SMMClient(object):
             rsp = await self.ipmicmd.raw_command(netfn=0x34, command=0x12, data=[1])
             if progress:
                 progress({'phase': 'initializing', 'progress': initpct})
-        wc = self.wc
+        wc = await self.wc()
         if wc is None:
             raise Exception("Failed to connect to web api")
         if variant and variant >> 5:
@@ -827,23 +828,19 @@ class SMMClient(object):
         fru['Model'] = mnum.strip(b' \x00\xff').replace(b'\xff', b'')
         return fru
 
-    def get_webclient(self):
+    async def get_webclient(self):
         cv = self.ipmicmd.certverify
-        wc = webclient.SecureHTTPConnection(self.smm, 443, verifycallback=cv)
         wc = webclient.WebConnection(self.smm, 443, verifycallback=cv)
         wc.vintage = util._monotonic_time()
-        wc.connect()
         loginform = urlencode(
             {
                 'user': self.username,
                 'password': self.password
             }
         )
-        wc.request('POST', '/data/login', loginform)
-        rsp = wc.getresponse()
-        if rsp.status != 200:
-            raise Exception(rsp.read())
-        authdata = rsp.read()
+        authdata, status, _ = await wc.grab_response_with_status('/data/login', loginform)
+        if status != 200:
+            raise Exception(authdata)
         authdata = fromstring(authdata)
         for data in authdata.findall('authResult'):
             if int(data.text) != 0:
@@ -860,11 +857,9 @@ class SMMClient(object):
             wc.st2 = data.text
         if not wc.st2:
             # This firmware puts tokens in the html file, parse that
-            wc.request('GET', '/index.html')
-            rsp = wc.getresponse()
-            if rsp.status != 200:
-                raise Exception(rsp.read())
-            indexhtml = rsp.read()
+            indexhtml, status, _ = await wc.grab_response_with_status('/index.html', method='GET')
+            if status != 200:
+                raise Exception(indexhtml)
             if not isinstance(indexhtml, str):
                 indexhtml = indexhtml.decode('utf8')
             for line in indexhtml.split('\n'):
@@ -875,10 +870,8 @@ class SMMClient(object):
                     wc.st2 = line.split()[-1].replace(
                         '"', '').replace(',', '')
         if not wc.st2:
-            wc.request('GET', '/scripts/index.ajs')
-            rsp = wc.getresponse()
-            body = rsp.read()
-            if rsp.status != 200:
+            body, status, _ = await wc.grab_response_with_status('/scripts/index.ajs', method='GET')
+            if status != 200:
                 raise Exception(body)
             if not isinstance(body, str):
                 body = body.decode('utf8')
@@ -1007,10 +1000,10 @@ class SMMClient(object):
                     data = z.open(filename)
                     break
         progress({'phase': 'upload', 'progress': 0.0})
-        wc = self.wc
-        wc.request('POST', '/data', 'set=fwType:10')  # SMM firmware
-        rsp = wc.getresponse()
-        rsp.read()
+        wc = await self.wc()
+        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=fwType:10')  # SMM firmware
+        if status != 200:
+            raise Exception(rsp)
         url = '/fwupload/fwupload.esp?ST1={0}'.format(wc.st1)
         fu = await webclient.make_uploader(
             wc, url, filename, data, formname='fileUpload',
@@ -1025,31 +1018,28 @@ class SMMClient(object):
                           'progress': 100 * await fu.get_progress()})
         progress({'phase': 'validating', 'progress': 0.0})
         url = '/data'
-        wc.request('POST', url, 'get=fwVersion,spfwInfo')
-        rsp = wc.getresponse()
-        rsp.read()
-        if rsp.status != 200:
+        rsp, status, _ = await wc.grab_response_with_status(url, 'get=fwVersion,spfwInfo')
+        if status != 200:
             raise Exception('Error validating firmware')
         progress({'phase': 'apply', 'progress': 0.0})
-        wc.request('POST', '/data', 'set=securityrollback:1')
-        wc.getresponse().read()
-        wc.request('POST', '/data', 'set=fwUpdate:1')
-        rsp = wc.getresponse()
-        rsp.read()
+        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=securityrollback:1')
+        if status != 200:
+            raise Exception(rsp)
+        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=fwUpdate:1')
+        if status != 200:
+            raise Exception(rsp)
         complete = False
         tries = 0
         while not complete:
             await ipmisession.Session.pause(3)
-            wc.request('POST', '/data', 'get=fwProgress,fwUpdate')
             try:
-                rsp = wc.getresponse()
-                progdata = rsp.read()
+                progdata, status, _ = await wc.grab_response_with_status('/data', 'get=fwProgress,fwUpdate')
             except Exception:
                 if tries > 2:
                      break
                 tries += 1
                 continue
-            if rsp.status != 200:
+            if status != 200:
                 raise Exception('Error applying firmware')
             progdata = fromstring(progdata)
             if progdata.findall('fwUpdate')[0].text == 'invalid signature':
@@ -1113,7 +1103,7 @@ class SMMClient(object):
         self._wc = None
 
     async def wc(self):
-        if (not self._wc or self._wc.broken
-                or self._wc.vintage < util._monotonic_time() + 30):
+        if (not self._wc or (self._wc.vintage
+                and self._wc.vintage < util._monotonic_time() - 30)):
             self._wc = await self.get_webclient()
         return self._wc

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -418,7 +418,7 @@ class SMMClient(object):
              'passwordReuseCheckNum,passwordFailAllowdNum,'
              'passwordLockoutTimePeriod,timeZone'))
         if status != 200:
-            raise Exception(rspbody)
+            raise Exception(rspbody.decode('utf8', 'replace'))
         accountinfo = fromstring(rspbody)
         for rule in self.rulemap:
             ruleinfo = accountinfo.find(self.rulemap[rule])
@@ -696,7 +696,7 @@ class SMMClient(object):
             rules = 'set={0}'.format(','.join(rules))
             rsp, status = await self.webrequest('/data', rules)
             if status != 200:
-                raise Exception(rsp)
+                raise Exception(rsp.decode('utf8', 'replace'))
         if powercfg != [None, None]:
             if variant != 6:
                 if None in powercfg:
@@ -739,7 +739,7 @@ class SMMClient(object):
                 '/data', 'set=user({0},1,{1},511,,4,15,0)'.format(
                     uid, username))
             if status != 200:
-                raise Exception(rsp)
+                raise Exception(rsp.decode('utf8', 'replace'))
 
     async def reseat_bay(self, bay):
         bay = int(bay)
@@ -842,7 +842,7 @@ class SMMClient(object):
         )
         authdata, status, _ = await wc.grab_response_with_status('/data/login', loginform)
         if status != 200:
-            raise Exception(authdata)
+            raise Exception(authdata.decode('utf8', 'replace'))
         authdata = fromstring(authdata)
         for data in authdata.findall('authResult'):
             if int(data.text) != 0:
@@ -861,7 +861,7 @@ class SMMClient(object):
             # This firmware puts tokens in the html file, parse that
             indexhtml, status, _ = await wc.grab_response_with_status('/index.html', method='GET')
             if status != 200:
-                raise Exception(indexhtml)
+                raise Exception(indexhtml.decode('utf8', 'replace'))
             if not isinstance(indexhtml, str):
                 indexhtml = indexhtml.decode('utf8')
             for line in indexhtml.split('\n'):
@@ -874,7 +874,7 @@ class SMMClient(object):
         if not wc.st2:
             body, status, _ = await wc.grab_response_with_status('/scripts/index.ajs', method='GET')
             if status != 200:
-                raise Exception(body)
+                raise Exception(body.decode('utf8', 'replace'))
             if not isinstance(body, str):
                 body = body.decode('utf8')
             for line in body.split('\n'):
@@ -894,7 +894,7 @@ class SMMClient(object):
         rsp, status = await self.webrequest(
             '/data', 'set=hostname:' + hostname)
         if status != 200:
-            raise Exception(rsp)
+            raise Exception(rsp.decode('utf8', 'replace'))
 
     async def get_hostname(self):
         currinfo = await self.get_netinfo()
@@ -906,7 +906,7 @@ class SMMClient(object):
         if status == 400:
             data, status = await self.webrequest('/data?get=hostname', '')
         if status != 200:
-            raise Exception(data)
+            raise Exception(data.decode('utf8', 'replace'))
         currinfo = fromstring(data)
         return currinfo
 
@@ -914,7 +914,7 @@ class SMMClient(object):
         rsp, status = await self.webrequest(
             '/data', 'set=dnsDomain:' + domain)
         if status != 200:
-            raise Exception(rsp)
+            raise Exception(rsp.decode('utf8', 'replace'))
 
     async def get_domain(self):
         currinfo = await self.get_netinfo()
@@ -924,7 +924,7 @@ class SMMClient(object):
     async def get_ntp_enabled(self, variant):
         rsp, status = await self.webrequest('/data', 'get=ntpOpMode')
         if status != 200:
-            raise Exception(rsp)
+            raise Exception(rsp.decode('utf8', 'replace'))
         info = fromstring(rsp)
         for data in info.findall('ntpOpMode'):
             return data.text == '1'
@@ -933,7 +933,7 @@ class SMMClient(object):
         result, status = await self.webrequest(
             '/data', 'set=ntpOpMode:{0}'.format(1 if enabled else 0))
         if status != 200:
-            raise Exception(result)
+            raise Exception(result.decode('utf8', 'replace'))
         if not isinstance(result, str):
             result = result.decode('utf8')
         if '<status>ok</status>' not in result:
@@ -943,7 +943,7 @@ class SMMClient(object):
         result, status = await self.webrequest(
             '/data', 'set=ntpServer{0}:{1}'.format(index + 1, server))
         if status != 200:
-            raise Exception(result)
+            raise Exception(result.decode('utf8', 'replace'))
         if not isinstance(result, str):
             result = result.decode('utf8')
         if '<status>ok</status>' not in result:
@@ -954,7 +954,7 @@ class SMMClient(object):
         rsp, status = await self.webrequest(
             '/data', 'get=ntpServer1,ntpServer2,ntpServer3')
         if status != 200:
-            raise Exception(rsp)
+            raise Exception(rsp.decode('utf8', 'replace'))
         result = fromstring(rsp)
         srvs = []
         for data in result.findall('ntpServer1'):
@@ -991,7 +991,7 @@ class SMMClient(object):
             rsp, status, _ = await wc.grab_response_with_status(
                 '/data', 'set=fwType:10')  # SMM firmware
             if status != 200:
-                raise Exception(rsp)
+                raise Exception(rsp.decode('utf8', 'replace'))
             url = '/fwupload/fwupload.esp?ST1={0}'.format(wc.st1)
             fu = await webclient.make_uploader(
                 wc, url, filename, data, formname='fileUpload',
@@ -1017,7 +1017,7 @@ class SMMClient(object):
             rsp, status, _ = await wc.grab_response_with_status(
                 '/data', 'set=fwUpdate:1')
             if status != 200:
-                raise Exception(rsp)
+                raise Exception(rsp.decode('utf8', 'replace'))
             complete = False
             tries = 0
             while not complete:

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -385,6 +385,7 @@ class SMMClient(object):
         self.password = ipmicmd.ipmi_session.password
         self._wc = None
         self.weblogging = False
+        self.updating = False
 
     async def clear_bmc_configuration(self):
         await self.ipmicmd.raw_command(0x32, 0xad)
@@ -798,15 +799,20 @@ class SMMClient(object):
             url = '/preview/smm-ffdc.tgz?ST1={0}'.format(wc.st1)
         if autosuffix and not savefile.endswith('.tgz'):
             savefile += '-smm-ffdc.tgz'
-        fd = webclient.make_downloader(wc, url, savefile)
-        while not fd.completed():
-            try:
-                await fd.join(1)
-            except asyncio.TimeoutError:
-                pass
-            if progress and await fd.get_progress():
-                progress({'phase': 'download',
-                          'progress': 100 * await fd.get_progress()})
+        # the download runs on this session, keep wc() from logging it out
+        self.updating = True
+        try:
+            fd = webclient.make_downloader(wc, url, savefile)
+            while not fd.completed():
+                try:
+                    await fd.join(1)
+                except asyncio.TimeoutError:
+                    pass
+                if progress and await fd.get_progress():
+                    progress({'phase': 'download',
+                              'progress': 100 * await fd.get_progress()})
+        finally:
+            self.updating = False
         if progress:
             progress({'phase': 'complete'})
         return savefile
@@ -985,53 +991,63 @@ class SMMClient(object):
                     break
         progress({'phase': 'upload', 'progress': 0.0})
         wc = await self.wc()
-        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=fwType:10')  # SMM firmware
-        if status != 200:
-            raise Exception(rsp)
-        url = '/fwupload/fwupload.esp?ST1={0}'.format(wc.st1)
-        fu = await webclient.make_uploader(
-            wc, url, filename, data, formname='fileUpload',
-            otherfields={'preConfig': 'on'})
-        while not fu.completed():
-            try:
-                await fu.join(3)
-            except asyncio.TimeoutError:
-                pass
-            if progress:
-                progress({'phase': 'upload',
-                          'progress': 100 * await fu.get_progress()})
-        progress({'phase': 'validating', 'progress': 0.0})
-        url = '/data'
-        rsp, status, _ = await wc.grab_response_with_status(url, 'get=fwVersion,spfwInfo')
-        if status != 200:
-            raise Exception('Error validating firmware')
-        progress({'phase': 'apply', 'progress': 0.0})
-        # only understood by newer SMM2 firmware, ignore rejection by older
-        await wc.grab_response_with_status('/data', 'set=securityrollback:1')
-        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=fwUpdate:1')
-        if status != 200:
-            raise Exception(rsp)
-        complete = False
-        tries = 0
-        while not complete:
-            await ipmisession.Session.pause(3)
-            try:
-                progdata, status, _ = await wc.grab_response_with_status('/data', 'get=fwProgress,fwUpdate')
-            except Exception:
-                if tries > 2:
-                    raise
-                tries += 1
-                continue
+        # the update runs on this session, keep wc() from logging it out
+        self.updating = True
+        try:
+            rsp, status, _ = await wc.grab_response_with_status(
+                '/data', 'set=fwType:10')  # SMM firmware
             if status != 200:
-                raise Exception('Error applying firmware')
-            progdata = fromstring(progdata)
-            if progdata.findall('fwUpdate')[0].text == 'invalid signature':
-                raise Exception('Firmware signature invalid')
-            percent = float(progdata.findall('fwProgress')[0].text)
+                raise Exception(rsp)
+            url = '/fwupload/fwupload.esp?ST1={0}'.format(wc.st1)
+            fu = await webclient.make_uploader(
+                wc, url, filename, data, formname='fileUpload',
+                otherfields={'preConfig': 'on'})
+            while not fu.completed():
+                try:
+                    await fu.join(3)
+                except asyncio.TimeoutError:
+                    pass
+                if progress:
+                    progress({'phase': 'upload',
+                              'progress': 100 * await fu.get_progress()})
+            progress({'phase': 'validating', 'progress': 0.0})
+            url = '/data'
+            rsp, status, _ = await wc.grab_response_with_status(
+                url, 'get=fwVersion,spfwInfo')
+            if status != 200:
+                raise Exception('Error validating firmware')
+            progress({'phase': 'apply', 'progress': 0.0})
+            # only understood by newer SMM2 firmware, ignore rejection by older
+            await wc.grab_response_with_status(
+                '/data', 'set=securityrollback:1')
+            rsp, status, _ = await wc.grab_response_with_status(
+                '/data', 'set=fwUpdate:1')
+            if status != 200:
+                raise Exception(rsp)
+            complete = False
+            tries = 0
+            while not complete:
+                await ipmisession.Session.pause(3)
+                try:
+                    progdata, status, _ = await wc.grab_response_with_status(
+                        '/data', 'get=fwProgress,fwUpdate')
+                except Exception:
+                    if tries > 2:
+                        raise
+                    tries += 1
+                    continue
+                if status != 200:
+                    raise Exception('Error applying firmware')
+                progdata = fromstring(progdata)
+                if progdata.findall('fwUpdate')[0].text == 'invalid signature':
+                    raise Exception('Firmware signature invalid')
+                percent = float(progdata.findall('fwProgress')[0].text)
 
-            progress({'phase': 'apply',
-                      'progress': percent})
-            complete = percent >= 100.0
+                progress({'phase': 'apply',
+                          'progress': percent})
+                complete = percent >= 100.0
+        finally:
+            self.updating = False
         return 'complete'
 
     async def get_inventory_descriptions(self, ipmicmd, variant):
@@ -1096,8 +1112,10 @@ class SMMClient(object):
         try:
             if (not self._wc or (self._wc.vintage
                     and self._wc.vintage < util._monotonic_time() - 30)):
-                # in case the existing session is still valid, dispose of it
-                await self.logout()
+                if not self.updating and self._wc:
+                    # in case the existing session is still valid, dispose
+                    # of it
+                    await self.logout()
                 self._wc = await self.get_webclient()
         finally:
             self.weblogging = False

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -384,6 +384,7 @@ class SMMClient(object):
         self.username = ipmicmd.ipmi_session.userid
         self.password = ipmicmd.ipmi_session.password
         self._wc = None
+        self.weblogging = False
 
     async def clear_bmc_configuration(self):
         await self.ipmicmd.raw_command(0x32, 0xad)
@@ -830,7 +831,6 @@ class SMMClient(object):
         cv = self.ipmicmd.certverify
         wc = webclient.WebConnection(self.smm, 443, verifycallback=cv)
         wc.set_header('Content-Type', 'application/x-www-form-urlencoded')
-        wc.vintage = util._monotonic_time()
         loginform = urlencode(
             {
                 'user': self.username,
@@ -884,6 +884,7 @@ class SMMClient(object):
         if not wc.st2:
             raise Exception('Unable to locate ST2 token')
         wc.set_header('ST2', wc.st2)
+        wc.vintage = util._monotonic_time()
         return wc
 
     async def set_hostname(self, hostname):
@@ -1093,10 +1094,21 @@ class SMMClient(object):
         if wc is None:
             return
         # best effort, a stale session must not fail the caller's operation
-        await wc.grab_response_with_status('/data/logout', None, method='POST')
+        try:
+            await wc.grab_response_with_status('/data/logout', None, method='POST')
+        except Exception:
+            pass
 
     async def wc(self):
-        if (not self._wc or (self._wc.vintage
-                and self._wc.vintage < util._monotonic_time() - 30)):
-            self._wc = await self.get_webclient()
+        while self.weblogging:
+            await ipmisession.Session.pause(0.25)
+        self.weblogging = True
+        try:
+            if (not self._wc or (self._wc.vintage
+                    and self._wc.vintage < util._monotonic_time() - 30)):
+                # in case the existing session is still valid, dispose of it
+                await self.logout()
+                self._wc = await self.get_webclient()
+        finally:
+            self.weblogging = False
         return self._wc

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -411,8 +411,7 @@ class SMMClient(object):
 
     async def get_bmc_configuration(self, variant):
         settings = {}
-        wc = await self.wc()
-        rspbody, status, _ = await wc.grab_response_with_status(
+        rspbody, status = await self.webrequest(
             '/data',
             ('get=passwordMinLength,passwordForceChange,passwordDurationDays,'
              'passwordExpireWarningDays,passwordChangeInterval,'
@@ -695,8 +694,7 @@ class SMMClient(object):
                             changeset[key]['value']))
         if rules:
             rules = 'set={0}'.format(','.join(rules))
-            wc = await self.wc()
-            rsp, status, _ = await wc.grab_response_with_status('/data', rules)
+            rsp, status = await self.webrequest('/data', rules)
             if status != 200:
                 raise Exception(rsp)
         if powercfg != [None, None]:
@@ -737,8 +735,7 @@ class SMMClient(object):
             username = bytes(rsp['data']).rstrip(b'\x00')
             if not isinstance(username, str):
                 username = username.decode('utf8')
-            wc = await self.wc()
-            await wc.grab_response_with_status(
+            await self.webrequest(
                 '/data', 'set=user({0},1,{1},511,,4,15,0)'.format(
                     uid, username))
 
@@ -892,8 +889,8 @@ class SMMClient(object):
         return wc
 
     async def set_hostname(self, hostname):
-        wc = await self.wc()
-        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=hostname:' + hostname)
+        rsp, status = await self.webrequest(
+            '/data', 'set=hostname:' + hostname)
         if status != 200:
             raise Exception(rsp)
 
@@ -903,18 +900,17 @@ class SMMClient(object):
             return data.text
 
     async def get_netinfo(self):
-        wc = await self.wc()
-        data, status, _ = await wc.grab_response_with_status('/data', 'get=hostname')
+        data, status = await self.webrequest('/data', 'get=hostname')
         if status == 400:
-            data, status, _ = await wc.grab_response_with_status('/data?get=hostname', '')
+            data, status = await self.webrequest('/data?get=hostname', '')
         if status != 200:
             raise Exception(data)
         currinfo = fromstring(data)
         return currinfo
 
     async def set_domain(self, domain):
-        wc = await self.wc()
-        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=dnsDomain:' + domain)
+        rsp, status = await self.webrequest(
+            '/data', 'set=dnsDomain:' + domain)
         if status != 200:
             raise Exception(rsp)
 
@@ -924,8 +920,7 @@ class SMMClient(object):
             return data.text
 
     async def get_ntp_enabled(self, variant):
-        wc = await self.wc()
-        rsp, status, _ = await wc.grab_response_with_status('/data', 'get=ntpOpMode')
+        rsp, status = await self.webrequest('/data', 'get=ntpOpMode')
         if status != 200:
             raise Exception(rsp)
         info = fromstring(rsp)
@@ -933,9 +928,8 @@ class SMMClient(object):
             return data.text == '1'
 
     async def set_ntp_enabled(self, enabled):
-        wc = await self.wc()
-        result, status, _ = await wc.grab_response_with_status('/data', 'set=ntpOpMode:{0}'.format(
-            1 if enabled else 0))
+        result, status = await self.webrequest(
+            '/data', 'set=ntpOpMode:{0}'.format(1 if enabled else 0))
         if status != 200:
             raise Exception(result)
         if not isinstance(result, str):
@@ -944,9 +938,8 @@ class SMMClient(object):
             raise Exception("Unrecognized result: " + result)
 
     async def set_ntp_server(self, server, index):
-        wc = await self.wc()
-        result, status, _ = await wc.grab_response_with_status('/data', 'set=ntpServer{0}:{1}'.format(
-            index + 1, server))
+        result, status = await self.webrequest(
+            '/data', 'set=ntpServer{0}:{1}'.format(index + 1, server))
         if status != 200:
             raise Exception(result)
         if not isinstance(result, str):
@@ -956,8 +949,7 @@ class SMMClient(object):
         return True
 
     async def get_ntp_servers(self):
-        wc = await self.wc()
-        rsp, status, _ = await wc.grab_response_with_status(
+        rsp, status = await self.webrequest(
             '/data', 'get=ntpServer1,ntpServer2,ntpServer3')
         if status != 200:
             raise Exception(rsp)
@@ -1121,3 +1113,13 @@ class SMMClient(object):
         finally:
             self.weblogging = False
         return self._wc
+
+    async def webrequest(self, url, data):
+        wc = await self.wc()
+        rsp, status, _ = await wc.grab_response_with_status(url, data)
+        if status == 401:
+            # the SMM dropped the session, log back in and try once more
+            self._wc = None
+            wc = await self.wc()
+            rsp, status, _ = await wc.grab_response_with_status(url, data)
+        return rsp, status

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -792,8 +792,6 @@ class SMMClient(object):
             if progress:
                 progress({'phase': 'initializing', 'progress': initpct})
         wc = await self.wc()
-        if wc is None:
-            raise Exception("Failed to connect to web api")
         if variant and variant >> 5:
             url = '/preview/smm2-ffdc.tgz?ST1={0}'.format(wc.st1)
         else:

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -890,11 +890,9 @@ class SMMClient(object):
         rsp, status, _ = await wc.grab_response_with_status('/data', 'set=hostname:' + hostname)
         if status != 200:
             raise Exception(rsp)
-        await self.logout()
 
     async def get_hostname(self):
         currinfo = await self.get_netinfo()
-        await self.logout()
         for data in currinfo.find('netConfig').findall('hostname'):
             return data.text
 
@@ -913,11 +911,9 @@ class SMMClient(object):
         rsp, status, _ = await wc.grab_response_with_status('/data', 'set=dnsDomain:' + domain)
         if status != 200:
             raise Exception(rsp)
-        await self.logout()
 
     async def get_domain(self):
         currinfo = await self.get_netinfo()
-        await self.logout()
         for data in currinfo.find('netConfig').findall('dnsDomain'):
             return data.text
 
@@ -927,7 +923,6 @@ class SMMClient(object):
         if status != 200:
             raise Exception(rsp)
         info = fromstring(rsp)
-        await self.logout()
         for data in info.findall('ntpOpMode'):
             return data.text == '1'
 
@@ -939,7 +934,6 @@ class SMMClient(object):
             raise Exception(result)
         if not isinstance(result, str):
             result = result.decode('utf8')
-        await self.logout()
         if '<status>ok</status>' not in result:
             raise Exception("Unrecognized result: " + result)
 
@@ -953,7 +947,6 @@ class SMMClient(object):
             result = result.decode('utf8')
         if '<status>ok</status>' not in result:
             raise Exception("Unrecognized result: " + result)
-        await self.logout()
         return True
 
     async def get_ntp_servers(self):
@@ -970,7 +963,6 @@ class SMMClient(object):
             srvs.append(data.text)
         for data in result.findall('ntpServer3'):
             srvs.append(data.text)
-        await self.logout()
         return srvs
 
     async def update_firmware(self, filename, data=None, progress=None, bank=None):

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -887,90 +887,84 @@ class SMMClient(object):
         wc.set_header('ST2', wc.st2)
         return wc
 
-    def set_hostname(self, hostname):
-        wc = self.wc
-        wc.request('POST', '/data', 'set=hostname:' + hostname)
-        rsp = wc.getresponse()
-        if rsp.status != 200:
-            raise Exception(rsp.read())
-        rsp.read()
-        self.logout()
+    async def set_hostname(self, hostname):
+        wc = await self.wc()
+        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=hostname:' + hostname)
+        if status != 200:
+            raise Exception(rsp)
+        await self.logout()
 
-    def get_hostname(self):
-        currinfo = self.get_netinfo()
-        self.logout()
+    async def get_hostname(self):
+        currinfo = await self.get_netinfo()
+        await self.logout()
         for data in currinfo.find('netConfig').findall('hostname'):
             return data.text
 
-    def get_netinfo(self):
-        wc = self.wc
-        wc.request('POST', '/data', 'get=hostname')
-        rsp = wc.getresponse()
-        data = rsp.read()
-        if rsp.status == 400:
-            wc.request('POST', '/data?get=hostname', '')
-            rsp = wc.getresponse()
-            data = rsp.read()
-        if rsp.status != 200:
+    async def get_netinfo(self):
+        wc = await self.wc()
+        data, status, _ = await wc.grab_response_with_status('/data', 'get=hostname')
+        if status == 400:
+            data, status, _ = await wc.grab_response_with_status('/data?get=hostname', '')
+        if status != 200:
             raise Exception(data)
         currinfo = fromstring(data)
         return currinfo
 
-    def set_domain(self, domain):
-        wc = self.wc
-        wc.request('POST', '/data', 'set=dnsDomain:' + domain)
-        rsp = wc.getresponse()
-        if rsp.status != 200:
-            raise Exception(rsp.read())
-        rsp.read()
-        self.logout()
+    async def set_domain(self, domain):
+        wc = await self.wc()
+        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=dnsDomain:' + domain)
+        if status != 200:
+            raise Exception(rsp)
+        await self.logout()
 
-    def get_domain(self):
-        currinfo = self.get_netinfo()
-        self.logout()
+    async def get_domain(self):
+        currinfo = await self.get_netinfo()
+        await self.logout()
         for data in currinfo.find('netConfig').findall('dnsDomain'):
             return data.text
 
-    def get_ntp_enabled(self, variant):
-        wc = self.wc
-        wc.request('POST', '/data', 'get=ntpOpMode')
-        rsp = wc.getresponse()
-        info = fromstring(rsp.read())
-        self.logout()
+    async def get_ntp_enabled(self, variant):
+        wc = await self.wc()
+        rsp, status, _ = await wc.grab_response_with_status('/data', 'get=ntpOpMode')
+        if status != 200:
+            raise Exception(rsp)
+        info = fromstring(rsp)
+        await self.logout()
         for data in info.findall('ntpOpMode'):
             return data.text == '1'
 
-    def set_ntp_enabled(self, enabled):
-        wc = self.wc
-        wc.request('POST', '/data', 'set=ntpOpMode:{0}'.format(
+    async def set_ntp_enabled(self, enabled):
+        wc = await self.wc()
+        result, status, _ = await wc.grab_response_with_status('/data', 'set=ntpOpMode:{0}'.format(
             1 if enabled else 0))
-        rsp = wc.getresponse()
-        result = rsp.read()
+        if status != 200:
+            raise Exception(result)
         if not isinstance(result, str):
             result = result.decode('utf8')
-        self.logout()
+        await self.logout()
         if '<status>ok</status>' not in result:
             raise Exception("Unrecognized result: " + result)
 
-    def set_ntp_server(self, server, index):
-        wc = self.wc
-        wc.request('POST', '/data', 'set=ntpServer{0}:{1}'.format(
+    async def set_ntp_server(self, server, index):
+        wc = await self.wc()
+        result, status, _ = await wc.grab_response_with_status('/data', 'set=ntpServer{0}:{1}'.format(
             index + 1, server))
-        rsp = wc.getresponse()
-        result = rsp.read()
+        if status != 200:
+            raise Exception(result)
         if not isinstance(result, str):
             result = result.decode('utf8')
         if '<status>ok</status>' not in result:
             raise Exception("Unrecognized result: " + result)
-        self.logout()
+        await self.logout()
         return True
 
-    def get_ntp_servers(self):
-        wc = self.wc
-        wc.request(
-            'POST', '/data', 'get=ntpServer1,ntpServer2,ntpServer3')
-        rsp = wc.getresponse()
-        result = fromstring(rsp.read())
+    async def get_ntp_servers(self):
+        wc = await self.wc()
+        rsp, status, _ = await wc.grab_response_with_status(
+            '/data', 'get=ntpServer1,ntpServer2,ntpServer3')
+        if status != 200:
+            raise Exception(rsp)
+        result = fromstring(rsp)
         srvs = []
         for data in result.findall('ntpServer1'):
             srvs.append(data.text)
@@ -978,7 +972,7 @@ class SMMClient(object):
             srvs.append(data.text)
         for data in result.findall('ntpServer3'):
             srvs.append(data.text)
-        self.logout()
+        await self.logout()
         return srvs
 
     async def update_firmware(self, filename, data=None, progress=None, bank=None):
@@ -1095,12 +1089,14 @@ class SMMClient(object):
             b' \x00\xff').decode('utf8'))
         return psui
 
-    def logout(self):
-        wc = self.wc
-        wc.request('POST', '/data/logout', None)
-        rsp = wc.getresponse()
-        rsp.read()
+    async def logout(self):
+        wc = self._wc
         self._wc = None
+        if wc is None:
+            return
+        rsp, status, _ = await wc.grab_response_with_status('/data/logout', None, method='POST')
+        if status != 200:
+            raise Exception(rsp)
 
     async def wc(self):
         if (not self._wc or (self._wc.vintage

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -735,9 +735,11 @@ class SMMClient(object):
             username = bytes(rsp['data']).rstrip(b'\x00')
             if not isinstance(username, str):
                 username = username.decode('utf8')
-            await self.webrequest(
+            rsp, status = await self.webrequest(
                 '/data', 'set=user({0},1,{1},511,,4,15,0)'.format(
                     uid, username))
+            if status != 200:
+                raise Exception(rsp)
 
     async def reseat_bay(self, bay):
         bay = int(bay)

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -1036,6 +1036,7 @@ class SMMClient(object):
                         raise
                     tries += 1
                     continue
+                tries = 0
                 if status != 200:
                     raise Exception('Error applying firmware')
                 progdata = fromstring(progdata)

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -736,11 +736,9 @@ class SMMClient(object):
             if not isinstance(username, str):
                 username = username.decode('utf8')
             wc = await self.wc()
-            rsp, status, _ = await wc.grab_response_with_status(
+            await wc.grab_response_with_status(
                 '/data', 'set=user({0},1,{1},511,,4,15,0)'.format(
                     uid, username))
-            if status != 200:
-                raise Exception(rsp)
 
     async def reseat_bay(self, bay):
         bay = int(bay)
@@ -831,6 +829,7 @@ class SMMClient(object):
     async def get_webclient(self):
         cv = self.ipmicmd.certverify
         wc = webclient.WebConnection(self.smm, 443, verifycallback=cv)
+        wc.set_header('Content-Type', 'application/x-www-form-urlencoded')
         wc.vintage = util._monotonic_time()
         loginform = urlencode(
             {
@@ -1016,9 +1015,8 @@ class SMMClient(object):
         if status != 200:
             raise Exception('Error validating firmware')
         progress({'phase': 'apply', 'progress': 0.0})
-        rsp, status, _ = await wc.grab_response_with_status('/data', 'set=securityrollback:1')
-        if status != 200:
-            raise Exception(rsp)
+        # only understood by newer SMM2 firmware, ignore rejection by older
+        await wc.grab_response_with_status('/data', 'set=securityrollback:1')
         rsp, status, _ = await wc.grab_response_with_status('/data', 'set=fwUpdate:1')
         if status != 200:
             raise Exception(rsp)
@@ -1094,9 +1092,8 @@ class SMMClient(object):
         self._wc = None
         if wc is None:
             return
-        rsp, status, _ = await wc.grab_response_with_status('/data/logout', None, method='POST')
-        if status != 200:
-            raise Exception(rsp)
+        # best effort, a stale session must not fail the caller's operation
+        await wc.grab_response_with_status('/data/logout', None, method='POST')
 
     async def wc(self):
         if (not self._wc or (self._wc.vintage

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -1029,7 +1029,7 @@ class SMMClient(object):
                 progdata, status, _ = await wc.grab_response_with_status('/data', 'get=fwProgress,fwUpdate')
             except Exception:
                 if tries > 2:
-                     break
+                    raise
                 tries += 1
                 continue
             if status != 200:

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -1030,9 +1030,16 @@ class SMMClient(object):
                         raise
                     tries += 1
                     continue
-                tries = 0
                 if status != 200:
-                    raise Exception('Error applying firmware')
+                    # an SMM restarting its web service part way through the
+                    # apply answers for a while before it stops answering at
+                    # all, so spend the same budget on this as on a poll that
+                    # went unanswered
+                    if tries > 2:
+                        raise Exception('Error applying firmware')
+                    tries += 1
+                    continue
+                tries = 0
                 progdata = fromstring(progdata)
                 if progdata.findall('fwUpdate')[0].text == 'invalid signature':
                     raise Exception('Firmware signature invalid')


### PR DESCRIPTION
On master the SMM web path is dead: every call site does `wc = self.wc`, which binds the coroutine method
rather than calling it, so the first `wc.request(...)` raises `AttributeError`. Nothing that talks to an SMM
over HTTPS works.

This ports those call sites onto `WebConnection.grab_response_with_status`, awaits the settings operations in
the Lenovo handler, and fixes the follow-on issues found while reviewing that port.

This is a follow up of https://github.com/xcat2/confluent/pull/235

_Note: AI assisted_

### Verification

| commit | fix |
|---|---|
| `fbbeda6c` | Port the web call sites off the removed `http.client` interface, make client creation async, and correct the cache expiry comparison (`vintage < now + 30` was always true, so the cache never hit; `_wc.broken` does not exist on `WebConnection`). |
| `8817ee6d` | Await the SMM settings helpers from the Lenovo handler; they returned unresolved coroutines. |
| `ca81907d` | Restore the `Content-Type: application/x-www-form-urlencoded` the old `request()` added, which `grab_response_with_status` only sets for dict payloads. Stop failing on responses the synchronous code discarded on purpose: `set=securityrollback:1` is newer-firmware only, and `/data/logout` answers 401 once the session is gone. |
| `5135a6cd` | Dispose of an expired session with a logout rather than dropping the reference, guard the login so two coroutines cannot both log in, and stamp `vintage` after the login round-trips. |
| `6e6cbce0` | An exhausted retry budget left the firmware poll loop with `complete` unset and fell through to `return 'complete'`, reporting an interrupted update as successful. |
| `474e2bd9` | Drop a `wc is None` check that `wc()` can never satisfy. |
| `1031bad4` | Stop logging out at the end of every getter and setter, which nulled the cache and made it inert on the paths it was meant to serve. |
| `d665064d` | A firmware update holds one session for the minutes its apply loop runs, and an FFDC collection holds the one it downloads on, but `wc()` judges a session by age alone, so a settings call arriving 30s in logged it out from underneath them. Flag long operations as the IMM and XCC handlers do. |
| `c3d6e0ae` | Nothing cleared the firmware poll retry counter, so three failures spread across a long apply aborted an update that was still progressing. |
| `65938639` | Route the `/data` calls through a helper that logs back in and retries once on a 401, so a session the SMM ended early does not reach the operator as a raw error body. |
| `f5a90f3e` | `set_user_priv` discarded its response, so a refused user record was reported as a successful privilege change. |
| `4d75c444` | The firmware poll loop aborted on the first non-200, though an SMM restarting its web service mid-apply keeps answering before it stops answering at all. A bad status now gets the same retry budget as a dead connection. |
| `ec7b96ec` | Every failure path raised the raw response bytes, putting `b'<status>error</status>'` in front of the operator instead of what the SMM said. |

## Verification

Run against a real DW612S enclosure (FPC variant 38, firmware 1.18) with [check_smm_live.py](https://github.com/user-attachments/files/30421574/check_smm_live.py).

```
System firmware_version: 1.18
System Device ID: 32
System Device Revision: 1
System Manufacturer ID: 19046
System Product ID: 1387
System Product name: ThinkSystem DW612S Neptune DWC Enclosure
System Manufacturer: Lenovo
System Model: 7D1LCTO2WW
```

**TODO**: I have no lab chassis available, therefore I couldn't run any firmware update tests.

| # | test | result |
|---|---|---|
| T1 | five handler getters share one login | pass, `logins=1`, 23 settings returned |
| T2 | four concurrent callers cause one login | pass, `logins=1`, all 200 |
| T3 | `vintage` stamped after the login round-trips | pass, login 1.66s |
| T4 | expired session replaced, old one dead server-side | pass, `logins=2`, old session answers 401 |
| T5 | held session survives a refresh while `updating` | pass, held session still answers 200 |
| T6 | reaped session re-established and retried once | pass, status 200 via exactly one extra login |
| T7 | four stray sessions coexist | pass, 4 concurrent, all logged out |
| T9 | hostname write, session reuse, restore | pass, web session answers 200 right after the write |
| T10 | domain write and restore | pass, web session answers 200 right after the write |
| T11 | `ntpServer3` write and restore | pass, wrote `192.0.2.1`, cleared again |
| T12 | NTP enable written with its current value | pass |
| T13 | service data collected, held session untouched | pass, 768 KB / 583-member archive, guard active, held session answers 200 |
| T8 | stray session lifetime | still alive after 20 min (cap) |

Notes:

- None of this can run on master: `wc = self.wc` binds the coroutine method, so the first `wc.request(...)`
  raises `AttributeError` before any request leaves the host.
- The 401 retry in `65938639` is exercised by T6, which reaps the session behind the client's back. The
  hostname and domain writes do **not** end the session on this firmware (T9, T10), so the retry covers a
  session the SMM drops on its own, not a self-inflicted one.
- Session reuse is worth roughly a 2s login per call avoided: five getters cost one login here, one per call
  before `1031bad4`.
- The session left behind by the last operation is not reaped quickly (T8), but four sessions coexist without
  complaint (T7), so the cost of holding one per chassis is bounded and no login was ever refused.
- `set_user_priv` (`f5a90f3e`) and the firmware paths (`c3d6e0ae`, `4d75c444`, and the `updating` wrap inside
  `update_firmware`) are not exercised against production hardware. The wrap itself is the same code T13
  exercises on the FFDC path. `ec7b96ec` is covered by a stub returning a non-200 with a non-ascii body.
