### PR TITLE
imgutil: fix async-port fallout in the image pack/capture path

### DIFF
--- a/confluent_server/bin/osdeploy
+++ b/confluent_server/bin/osdeploy
@@ -10,7 +10,6 @@ import os.path
 import pwd
 import shutil
 import sys
-import time
 
 path = os.path.dirname(os.path.realpath(__file__))
 path = os.path.realpath(os.path.join(path, '..', 'lib', 'python'))
@@ -597,7 +596,7 @@ async def osimport(imagefile, checkonly=False, custname=None):
                     sys.stdout.flush()
                 else:
                     print(repr(rsp))
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
     finally:
         if shortname:
             async for x in c.delete('/deployment/importing/{0}'.format(shortname)):

--- a/confluent_server/confluent/osimage.py
+++ b/confluent_server/confluent/osimage.py
@@ -1275,32 +1275,37 @@ class MediaImporter(object):
             nb = await wkr.stdout.read(128)
             currline += nb
             if b'\r' in currline:
-                if b'%' in currline:
-                    val = currline.split(b'%')[0].strip()
-                    if val:
-                        self.percent = float(val)
-                elif b'ERROR:' in currline:
+                if b'ERROR:' in currline:
                     self.error = currline.replace(b'ERROR:', b'')
                     if not isinstance(self.error, str):
                         self.error = self.error.decode('utf8')
                     self.phase = 'error'
                     self.percent = 100.0
                     return
+                elif b'%' in currline:
+                    val = currline.split(b'%')[0].strip()
+                    try:
+                        self.percent = float(val)
+                    except ValueError:
+                        pass
                 currline = b''
         a = await wkr.stdout.read(1)
         while a:
             currline += a
             if b'\r' in currline:
-                if b'%' in currline:
-                    val = currline.split(b'%')[0].strip()
-                    if val:
-                        self.percent = float(val)
-                elif b'ERROR:' in currline:
+                if b'ERROR:' in currline:
                     self.error = currline.replace(b'ERROR:', b'')
                     if not isinstance(self.error, str):
                         self.error = self.error.decode('utf8')
                     self.phase = 'error'
+                    self.percent = 100.0
                     return
+                elif b'%' in currline:
+                    val = currline.split(b'%')[0].strip()
+                    try:
+                        self.percent = float(val)
+                    except ValueError:
+                        pass
                 currline = b''
             a = await wkr.stdout.read(1)
         if self.oscategory:

--- a/confluent_server/confluent/osimage.py
+++ b/confluent_server/confluent/osimage.py
@@ -1041,11 +1041,11 @@ def copy_file(src, dst):
 async def get_hash(fname):
     currhash = hashlib.sha512()
     with open(fname, 'rb') as currf:
-        currd = currf.read(2048)
+        currd = currf.read(1048576)
         await asyncio.sleep(0)
         while currd:
             currhash.update(currd)
-            currd = currf.read(2048)
+            currd = currf.read(1048576)
             await asyncio.sleep(0)
 
     return currhash.hexdigest()

--- a/confluent_server/confluent/osimage.py
+++ b/confluent_server/confluent/osimage.py
@@ -1301,7 +1301,7 @@ class MediaImporter(object):
                         self.error = self.error.decode('utf8')
                     self.phase = 'error'
                     return
-            currline = b''
+                currline = b''
             a = await wkr.stdout.read(1)
         if self.oscategory:
             defprofile = '/opt/confluent/lib/osdeploy/{0}'.format(

--- a/confluent_server/confluent/osimage.py
+++ b/confluent_server/confluent/osimage.py
@@ -834,7 +834,7 @@ def fingerprint_initramfs(archive):
     return None
 
 
-async def scan_iso(archive):
+def scan_iso(archive):
     scanudf = False
     filesizes = {}
     filecontents = {}
@@ -845,7 +845,6 @@ async def scan_iso(archive):
             for ent in reader:
                 if str(ent).endswith('TRANS.TBL'):
                     continue
-                await asyncio.sleep(0)
                 filesizes[str(ent)] = ent.size
                 if str(ent) == 'README.TXT':
                     readmecontents = b''
@@ -909,13 +908,13 @@ def parse_bfb(archive):
             archive.seek(currsize, os.SEEK_CUR)
     return None
 
-async def fingerprint(archive):
+def fingerprint(archive):
     archive.seek(0)
     header = archive.read(32768)
     archive.seek(32769)
     if archive.read(6) == b'CD001\x01':
         # ISO image
-        isoinfo = await scan_iso(archive)
+        isoinfo = scan_iso(archive)
         name = None
         for fun in globals():
             if fun.startswith('check_'):
@@ -947,7 +946,7 @@ async def import_image(filename, callback, backend=False, mfd=None, custtargpath
         archive = os.fdopen(int(mfd), 'rb')
     else:
         archive = open(filename, 'rb')
-    identity = await fingerprint(archive)
+    identity = await asyncio.to_thread(fingerprint, archive)
     if not identity:
         return -1
     identity, imginfo, funname = identity
@@ -1207,7 +1206,7 @@ class MediaImporter(object):
         else:
             medfile = open(media, 'rb')
         try:
-            identity = await fingerprint(medfile)
+            identity = await asyncio.to_thread(fingerprint, medfile)
         finally:
             if not self.medfile:
                 medfile.close()

--- a/confluent_server/confluent/util.py
+++ b/confluent_server/confluent/util.py
@@ -52,6 +52,8 @@ def mkdirp(path, mode=0o777):
 
 
 async def check_call(*cmd, **kwargs):
+    if len(cmd) == 1 and isinstance(cmd[0], (list, tuple)):
+        cmd = cmd[0]
     subproc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
     rc = await subproc.wait()
     if rc != 0:

--- a/imgutil/imgutil
+++ b/imgutil/imgutil
@@ -26,7 +26,7 @@ import time
 try:
     import yaml
 except ImportError:
-    pass
+    yaml = None
 path = os.path.dirname(os.path.realpath(__file__))
 path = os.path.realpath(os.path.join(path, '..', 'lib', 'python'))
 if path.startswith('/opt'):
@@ -197,6 +197,18 @@ def build_el_boot_tree(targpath):
     gather_bootloader(targpath)
 
 
+def write_manifest(outdir, indir):
+    if not (osimage and yaml):
+        sys.stderr.write('Warning: confluent server libraries unavailable, skipping manifest.yaml, '
+                         'osdeploy rebase will not work for this profile\n')
+        return
+    hmap = asyncio.run(osimage.get_hashes(outdir, indir))
+    with open('{0}/manifest.yaml'.format(outdir), 'w') as yout:
+        yout.write('# This manifest enables rebase to know original source of profile data and if any customizations have been done\n')
+        manifestdata = {'distdir': indir, 'disthashes': hmap}
+        yout.write(yaml.dump(manifestdata, default_flow_style=False))
+
+
 def capture_remote(args):
     targ = args.node
     outdir = args.profilename
@@ -267,11 +279,7 @@ def capture_remote(args):
     indir = '{}/profiles/default'.format(confdir)
     if os.path.exists(indir):
         copy_tree(indir, outdir)
-        hmap = asyncio.run(osimage.get_hashes(outdir, indir))
-        with open('{0}/manifest.yaml'.format(outdir), 'w') as yout:
-            yout.write('# This manifest enables rebase to know original source of profile data and if any customizations have been done\n')
-            manifestdata = {'distdir': indir, 'disthashes': hmap}
-            yout.write(yaml.dump(manifestdata, default_flow_style=False))
+        write_manifest(outdir, indir)
     label = '{0} {1} ({2})'.format(finfo['name'], finfo['version'], profname)
     with open(os.path.join(outdir, 'profile.yaml'), 'w') as profileout:
         profileout.write('label: {}\n'.format(label))
@@ -1672,11 +1680,7 @@ def pack_image(args):
             indir = '{}/profiles/default'.format(confdir)
             if os.path.exists(indir):
                 copy_tree(indir, outdir)
-                hmap = asyncio.run(osimage.get_hashes(outdir, indir))
-                with open('{0}/manifest.yaml'.format(outdir), 'w') as yout:
-                    yout.write('# This manifest enables rebase to know original source of profile data and if any customizations have been done\n')
-                    manifestdata = {'distdir': indir, 'disthashes': hmap}
-                    yout.write(yaml.dump(manifestdata, default_flow_style=False))
+                write_manifest(outdir, indir)
             tryupdate = True
     try:
         pwd.getpwnam('confluent')

--- a/imgutil/imgutil
+++ b/imgutil/imgutil
@@ -385,28 +385,37 @@ def encrypt_image(plainfile, cryptfile, keyfile):
         neededblocks += 1
     loopdev = subprocess.check_output(['losetup', '-f']).decode('utf8').strip()
     subprocess.check_call(['losetup', loopdev, cryptfile])
-    subprocess.check_call(['dmsetup', 'create', dmname, '--table', '0 {} crypt aes-xts-plain64 {} 0 {} 8'.format(neededblocks, key, loopdev)])
-    subprocess.check_call(['dmsetup', 'mknodes', dmname])
-    with open('/dev/mapper/{}'.format(dmname), 'wb') as cryptout:
-        with open(plainfile, 'rb+') as plainin:
-            lastoffset = 0
-            chunk = plainin.read(2097152)
-            while chunk:
-                fallocate(plainin.fileno(), FALLOC_FL_KEEP_SIZE|FALLOC_FL_PUNCH_HOLE, lastoffset, len(chunk))
-                lastoffset = plainin.tell()
-                cryptout.write(chunk)
+    try:
+        subprocess.check_call(['dmsetup', 'create', dmname, '--table', '0 {} crypt aes-xts-plain64 {} 0 {} 8'.format(neededblocks, key, loopdev)])
+        subprocess.check_call(['dmsetup', 'mknodes', dmname])
+        with open('/dev/mapper/{}'.format(dmname), 'wb') as cryptout:
+            with open(plainfile, 'rb+') as plainin:
+                lastoffset = 0
                 chunk = plainin.read(2097152)
-    mounted = True
-    tries = 30
-    time.sleep(0.1)
-    while mounted:
-        tries -= 1
-        try:
-            subprocess.check_call(['dmsetup', 'remove', dmname])
-            mounted = False
-        except subprocess.CalledProcessError:
-            time.sleep(0.1)
-    subprocess.check_call(['losetup', '-d', loopdev])
+                while chunk:
+                    fallocate(plainin.fileno(), FALLOC_FL_KEEP_SIZE|FALLOC_FL_PUNCH_HOLE, lastoffset, len(chunk))
+                    lastoffset = plainin.tell()
+                    cryptout.write(chunk)
+                    chunk = plainin.read(2097152)
+    finally:
+        mounted = True
+        tries = 30
+        time.sleep(0.1)
+        while mounted and tries:
+            tries -= 1
+            try:
+                subprocess.check_call(['dmsetup', 'remove', dmname])
+                mounted = False
+            except subprocess.CalledProcessError:
+                time.sleep(0.1)
+        if mounted:
+            sys.stderr.write(
+                'Warning: unable to remove {0}, it and {1} are left behind\n'.format(dmname, loopdev))
+        else:
+            try:
+                subprocess.check_call(['losetup', '-d', loopdev])
+            except subprocess.CalledProcessError:
+                sys.stderr.write('Warning: unable to detach {0}\n'.format(loopdev))
     oum = os.umask(0o077)
     with open(keyfile, 'w') as keyout:
         keyout.write('aes-xts-plain64\n{}\n'.format(key))

--- a/imgutil/imgutil
+++ b/imgutil/imgutil
@@ -197,7 +197,7 @@ def build_el_boot_tree(targpath):
     gather_bootloader(targpath)
 
 
-async def capture_remote(args):
+def capture_remote(args):
     targ = args.node
     outdir = args.profilename
     os.umask(0o022)
@@ -267,7 +267,7 @@ async def capture_remote(args):
     indir = '{}/profiles/default'.format(confdir)
     if os.path.exists(indir):
         copy_tree(indir, outdir)
-        hmap = await osimage.get_hashes(outdir, indir)
+        hmap = asyncio.run(osimage.get_hashes(outdir, indir))
         with open('{0}/manifest.yaml'.format(outdir), 'w') as yout:
             yout.write('# This manifest enables rebase to know original source of profile data and if any customizations have been done\n')
             manifestdata = {'distdir': indir, 'disthashes': hmap}
@@ -1015,13 +1015,13 @@ def main():
     if args.subcommand == 'build':
         build_root(args)
     elif args.subcommand == 'capture':
-        asyncio.run(capture_remote(args))
+        capture_remote(args)
     elif args.subcommand == 'unpack':
         unpack_image(args)
     elif args.subcommand == 'exec':
         exec_root(args)
     elif args.subcommand == 'pack':
-        asyncio.run(pack_image(args))
+        pack_image(args)
     else:
         parser.print_usage()
 
@@ -1544,7 +1544,7 @@ def recursecp(source, targ):
         shutil.copy2(source, targ)
 
 
-async def pack_image(args):
+def pack_image(args):
     outdir = args.profilename
     if '/' in outdir:
         raise Exception('Full path not supported, supply only the profile name\n')
@@ -1663,7 +1663,7 @@ async def pack_image(args):
             indir = '{}/profiles/default'.format(confdir)
             if os.path.exists(indir):
                 copy_tree(indir, outdir)
-                hmap = await osimage.get_hashes(outdir, indir)
+                hmap = asyncio.run(osimage.get_hashes(outdir, indir))
                 with open('{0}/manifest.yaml'.format(outdir), 'w') as yout:
                     yout.write('# This manifest enables rebase to know original source of profile data and if any customizations have been done\n')
                     manifestdata = {'distdir': indir, 'disthashes': hmap}

--- a/imgutil/imgutil
+++ b/imgutil/imgutil
@@ -267,7 +267,7 @@ async def capture_remote(args):
     indir = '{}/profiles/default'.format(confdir)
     if os.path.exists(indir):
         copy_tree(indir, outdir)
-        hmap = await osimage.get_hashes(outdir)
+        hmap = await osimage.get_hashes(outdir, indir)
         with open('{0}/manifest.yaml'.format(outdir), 'w') as yout:
             yout.write('# This manifest enables rebase to know original source of profile data and if any customizations have been done\n')
             manifestdata = {'distdir': indir, 'disthashes': hmap}
@@ -1663,7 +1663,7 @@ async def pack_image(args):
             indir = '{}/profiles/default'.format(confdir)
             if os.path.exists(indir):
                 copy_tree(indir, outdir)
-                hmap = await osimage.get_hashes(outdir)
+                hmap = await osimage.get_hashes(outdir, indir)
                 with open('{0}/manifest.yaml'.format(outdir), 'w') as yout:
                     yout.write('# This manifest enables rebase to know original source of profile data and if any customizations have been done\n')
                     manifestdata = {'distdir': indir, 'disthashes': hmap}


### PR DESCRIPTION
This PR fixes a few imgutil asyncio related issues.
Furthermore, the root image is not hashed anymore in manifest.yaml. It's unused anyways, but this should be reviewd carefully. Several adjacent bugs surfaced while testing and are fixed here too.

_Note: AI assisted_

| commit | fix |
|---|---|
| 1a9613f2 | `get_hash` read 2048 bytes per iteration with a yield each time, doubling hashing cost (1.35 s vs 0.62 s per 512 MB). Now 1 MiB. sha512 is independent of read size, so digests and existing manifests are unaffected. |
| aba56491 | `capture`/`pack` hashed `rootimg.sfs` and the boot blobs into `manifest.yaml`, where `rebase_profile` can never read them. Both sites now filter by the source dir, as `generate_stock_profiles` does. |
| 38be080b | `check_call` lacked the single-list unwrapping `check_output` has, so a list argument raised `TypeError`. Hits the `genisoimage` run behind Windows imports, where an `except Exception` swallows it and the `boot.iso` is silently missing, and the `nodeconfig` run in discovery. |
| 4e905201 | `capture_remote`/`pack_image` were `async def` for one awaited call, deferring interrupts across minutes of blocking work. See below. |
| 547ecf16 | `encrypt_image` had no `try/finally`, so an interrupted copy stranded a dm-crypt mapping and a loop device holding the profile's `rootimg.sfs`. Teardown moves into a `finally`, honours its `tries` counter, and warns rather than raising so it cannot mask the exception that triggered it. |
| f2c74b0b | `scan_iso`/`fingerprint` walked an ISO with blocking reads on the daemon loop, on every fingerprint and import. About 8 us per entry (80 ms at 10k, independent of media size), and the header-sum branch reads a whole multi-gigabyte image. Now plain functions via `asyncio.to_thread`. |
| b081c17b | The importer's drain loop cleared `currline` every byte, so its percentage and `ERROR:` branches could never match. |
| 3e7da14a | Both drain loops tested for `%` before `ERROR:`, so an error whose text carries a `%` reached `float()` and raised; an import name can carry one too, and it is user supplied. `importmedia` is a bare task, so the exception was swallowed and the client polled a phase that never advanced. |
| 99568450 | `osdeploy osimport` used a blocking `time.sleep(0.5)` inside its async poll loop. |
| 4f112fb7 | `imgutil` dereferenced `osimage`/`yaml` unconditionally despite their optional imports, so a server-less install raised instead of producing a profile. |

## On the interrupt fix

From Python 3.11 `asyncio.run` cancels the main task on SIGINT rather than raising, so an interrupt is only
seen at the next `await`. With `pack_image` a coroutine whose one `await` sits at the very end, interrupting
a pack during `encrypt_image` surfaced 2.4 s late and `osdeploy updateboot` still ran: the operator
interrupted, and imgutil published the profile anyway. As plain functions it aborts in ~0.2 s. Python 3.11+
only; EL9 (3.9) has no `asyncio.Runner` and was verified as an unaffected control.

`get_hash`/`get_hashes` deliberately stay coroutines. Converting them to `to_thread` was tried and dropped:
0.8% slower at the same chunk size, indistinguishable at the real workload (20 files, 0.6 ms), and
incompatible across the `confluent_server` / `confluent_imgutil` package boundary, which have no dependency
on each other.

## Testing

Lab on alma9 (py3.9) and alma10 (py3.12), snapshotted beforehand and reverted after. Encrypted `pack` +
`unpack` round trip of a 1 GB diskless profile (34240 files both sides, identical `/etc/os-release`, no
leftover devices); manifests hold only profile-source files with every digest verified against the packed
file; `osdeploy rebase` returns 0 on packed, stock and legacy manifests and flags a customised script;
`check_call` with list, tuple and varargs; `encrypt_image` teardown bounded at 30 tries, warning without
masking the original exception.

Interrupting a pack aborts in 0.16-0.26 s with rc 130 and releases both devices, where the pre-PR imgutil
left `/dev/loop0` still holding the profile's `rootimg.sfs` on py3.9 and published the profile despite the
interrupt on py3.12. Importing with `-n 'pct%test'` against an unwritable target reports
`Permission denied` in 1 s; with only the two lines of `3e7da14a` reverted in the running daemon the same
command hangs until the 60 s timeout.