### PR TITLE
Apply chown before chmod in syncfileclient permission handling

### DIFF
--- a/confluent_osdeploy/common/profile/scripts/syncfileclient
+++ b/confluent_osdeploy/common/profile/scripts/syncfileclient
@@ -301,6 +301,7 @@ def synchronize():
                 for fname in opts:
                     uid = -1
                     gid = -1
+                    perms = None
                     for opt in opts[fname]:
                         if opt == 'owner':
                             try:
@@ -309,16 +310,21 @@ def synchronize():
                                 try:
                                     uid = opts[fname][opt]['id']
                                 except KeyError:
-                                    raise Exception(f"Unable to map owner of {fname}") 
+                                    raise Exception(f"Unable to map owner of {fname}")
                         elif opt == 'group':
                             try:
                                 gid = grp.getgrnam(opts[fname][opt]['name']).gr_gid
                             except KeyError:
                                 gid = opts[fname][opt]['id']
                         elif opt == 'permissions':
-                            os.chmod(fname, int(opts[fname][opt], 8))
+                            perms = int(opts[fname][opt], 8)
                     if uid != -1 or gid != -1:
+                        # chown clears setuid (and setgid on a group-executable
+                        # file), even for root, so it must happen before the
+                        # chmod that applies them
                         os.chown(fname, uid, gid)
+                    if perms is not None:
+                        os.chmod(fname, perms)
         return status
     finally:
         shutil.rmtree(tmpdir)

--- a/confluent_osdeploy/el7-diskless/profiles/default/scripts/syncfileclient
+++ b/confluent_osdeploy/el7-diskless/profiles/default/scripts/syncfileclient
@@ -287,6 +287,7 @@ def synchronize():
                 for fname in opts:
                     uid = -1
                     gid = -1
+                    perms = None
                     for opt in opts[fname]:
                         if opt == 'owner':
                             try:
@@ -299,9 +300,14 @@ def synchronize():
                             except KeyError:
                                 gid = opts[fname][opt]['id']
                         elif opt == 'permissions':
-                            os.chmod(fname, int(opts[fname][opt], 8))
+                            perms = int(opts[fname][opt], 8)
                     if uid != -1 or gid != -1:
+                        # chown clears setuid (and setgid on a group-executable
+                        # file), even for root, so it must happen before the
+                        # chmod that applies them
                         os.chown(fname, uid, gid)
+                    if perms is not None:
+                        os.chmod(fname, perms)
     finally:
         shutil.rmtree(tmpdir)
         shutil.rmtree(appendoncedir)

--- a/confluent_osdeploy/el7/profiles/default/scripts/syncfileclient
+++ b/confluent_osdeploy/el7/profiles/default/scripts/syncfileclient
@@ -287,6 +287,7 @@ def synchronize():
                 for fname in opts:
                     uid = -1
                     gid = -1
+                    perms = None
                     for opt in opts[fname]:
                         if opt == 'owner':
                             try:
@@ -299,9 +300,14 @@ def synchronize():
                             except KeyError:
                                 gid = opts[fname][opt]['id']
                         elif opt == 'permissions':
-                            os.chmod(fname, int(opts[fname][opt], 8))
+                            perms = int(opts[fname][opt], 8)
                     if uid != -1 or gid != -1:
+                        # chown clears setuid (and setgid on a group-executable
+                        # file), even for root, so it must happen before the
+                        # chmod that applies them
                         os.chown(fname, uid, gid)
+                    if perms is not None:
+                        os.chmod(fname, perms)
     finally:
         shutil.rmtree(tmpdir)
         shutil.rmtree(appendoncedir)


### PR DESCRIPTION
chown() clears the setuid bit of a file on Linux (and its setgid bit, if the file is group-executable), even when run by root and even when the owner/group are unchanged. Since the owner/group chown ran after the permissions chmod, any syncfiles entry combining `owner=/group= `with a setuid/setgid `permissions=` value silently lost the special bits.

E.g.:

```
/usr/local/bin/ws_allocate -> login,compute:/usr/local/bin/ws_allocate (owner=root,group=root,permissions=4755)
```

Would set 0755 instead.

```
/usr/local/bin/ws_allocate -> login,compute:/usr/local/bin/ws_allocate (permissions=4755)
```

works.