### PR TITLE
Preserve attributes in syncfiles without disturbing parent directories

### DIFF
--- a/confluent_server/confluent/syncfiles.py
+++ b/confluent_server/confluent/syncfiles.py
@@ -191,12 +191,33 @@ async def sync_list_to_node(sl, node, suffixes, peerip=None):
             for ent in sl.appendoncemap:
                 stage_ent(sl.appendoncemap, ent,
                           os.path.join(targdir, suffixes['appendonce']), True)
+        filelist = []
+        for root, dirs, files in os.walk(targdir):
+            if not dirs and not files and root != targdir:
+                # otherwise empty directories have to be named to be synced
+                filelist.append(os.path.relpath(root, targdir))
+            for filename in files:
+                filelist.append(
+                    os.path.relpath(os.path.join(root, filename), targdir))
         await sshutil.prep_ssh_key('/etc/confluent/ssh/automation')
         targip = node
         if peerip:
             targip = peerip
+        # Naming every file (--files-from implies --relative) together with
+        # --no-implied-dirs confines the preservation flags to the content
+        # actually being synchronized. Without it, the parent directories
+        # traversed on the way get the attributes of the staging copy, which
+        # is what forced preservation to be rolled back in the past.
         output, stderr = await util.check_output(
-            'rsync', '-rvLD', targdir + '/', 'root@[{}]:/'.format(targip))
+            'rsync', '-vLpgotDA', '--no-implied-dirs', '--files-from=-',
+            # content out of confluent's own storage is owned by the account
+            # the daemon runs as, which normally does not exist on the node
+            # and would arrive as a meaningless numeric id; every other owner
+            # is still matched by name as usual
+            '--usermap={}:root'.format(os.getuid()),
+            '--groupmap={}:root'.format(os.getgid()),
+            targdir + '/', 'root@[{}]:/'.format(targip),
+            input=''.join([x + '\n' for x in filelist]).encode('utf8'))
     except subprocess.CalledProcessError as e:
         unreadablefiles = []
         for root, dirnames, filenames in os.walk(targdir):
@@ -251,6 +272,15 @@ def stage_ent(currmap, ent, targdir, appendexist=False):
 def mkpathorlink(source, destination, appendexist=False):
     if os.path.isdir(source):
         mkdirp(destination)
+        # Files are staged as symlinks, so rsync reads their attributes
+        # through to the real file, but a directory is staged as a directory
+        # and has to be given the source attributes to pass them along.
+        srcstat = os.stat(source)
+        shutil.copystat(source, destination)
+        try:
+            os.chown(destination, srcstat.st_uid, srcstat.st_gid)
+        except OSError:  # lacking CAP_CHOWN, leave it owned by the daemon
+            pass
         for ent in os.listdir(source):
             currsrc = os.path.join(source, ent)
             currdst = os.path.join(destination, ent)

--- a/confluent_server/confluent/util.py
+++ b/confluent_server/confluent/util.py
@@ -63,12 +63,13 @@ async def check_call(*cmd, **kwargs):
 
 
 
-async def check_output(*cmd):
+async def check_output(*cmd, input=None):
     if len(cmd) == 1 and isinstance(cmd[0], (list, tuple)):
         cmd = cmd[0]
     process = await asyncio.create_subprocess_exec(
-        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
-    stdout, stderr = await process.communicate()
+        *cmd, stdin=asyncio.subprocess.PIPE if input is not None else None,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+    stdout, stderr = await process.communicate(input)
     retcode = process.returncode
     if retcode:
         raise subprocess.CalledProcessError(


### PR DESCRIPTION
## Problem

The syncfiles rsync push carried no preservation flags:

```
rsync -rvLD <staging>/ root@[node]:/
```

Without `-p`, rsync explicitly disables setuid/setgid/sticky on new files, so a syncfile entry could never deliver
a setuid binary, and existing files on the node kept whatever mode they already had.

## Why the flags could not just be added back

It was tried once in [`e52a9ff7`](https://github.com/xcat2/confluent/commit/e52a9ff70feec53974f5aa55c9be20505746bf7e)
("Have syncfiles attempt to preserve more") and rolled back in [`c0287e93`](https://github.com/xcat2/confluent/commit/c0287e93edf6526765f69bb907b3ce545b57e17f):
*"Unfortunately, it will try to change parent directories on the way to the files actually being written."*

The staging tree mirrors the full destination path, so `-r` walks it as real directory entries and rsync applied
the staging directory's attributes to the real `/etc` on the node. Naming every staged file through `--files-from`
plus `--no-implied-dirs` confines preservation to the content actually being synchronized:

```
rsync -vLpgotDA --no-implied-dirs --files-from=- \
      --usermap=<confluent uid>:root --groupmap=<confluent gid>:root \
      <staging>/ root@[node]:/
```

## What changed

- The file list is built in memory and fed to `--files-from=-` on stdin. Otherwise empty directories are named
  explicitly, since nothing else would pull them across.
- `util.check_output` gained a keyword only `input=`, mirroring `subprocess.run`. `stdin` is only piped when
  `input` is given, so existing callers are unaffected.
- `mkpathorlink` copies the source directory's attributes onto the staged copy. Files are staged as symlinks and
  rsync reads through to the real file, but directories are staged as directories.
- The confluent account's ownership is mapped to root via `--usermap`/`--groupmap`, since it normally does not
  exist on the node. Every other owner still matches by name, so this is not a blanket `--chown`.
- `--xattrs` from the earlier attempt is left out: with `--copy-links` rsync reads xattrs off the symlink, not its
  referent, so it transfers nothing here while adding a failure mode on hosts without xattr support.

> [!WARNING]
> **This changes existing syncfiles behaviour.** Attributes that used to be left alone are now taken from the
> source on every sync:
>
> - **Permissions are asserted every time.** Existing files on the node previously kept their own mode, so a local
>   `chmod` on a synced file survived. It is now reverted on the next sync.
> - **Ownership comes from the server.** Synced files used to land `root:root` regardless of the source. A file
>   owned by a named account now arrives owned by that account, matched by name, falling back to the server's
>   numeric id when that name does not exist on the node. Only the confluent account is mapped to root.
> - **Timestamps and ACLs are carried over** (`-t`, `-A`), where previously they were not.
>
> Directories that are only traversed on the way to a synced file remain untouched, which is what the second test
> table below covers.

## Testing

End to end against a deployed AlmaLinux 10 node, same fixture before and after.

Files and directories delivered by the sync:

| synced item          | path                        | source on server           | before                 | after               |
| -------------------- | --------------------------- | -------------------------- | ---------------------- | ------------------- |
| setuid binary        | `/opt/sync/sub/setuidapp`   | `4755 root:root`           | `755`                  | `4755 root:root`    |
| setgid binary        | `/opt/sync/sub/setgidapp`   | `2755 root:root`           | `755`                  | `2755 root:root`    |
| existing file        | `/opt/sync/sub/tightmode`   | `0640 root:confluent`      | `666`, stale mode kept | `640 root:root`     |
| confluent owned file | `/opt/sync/sub/cflowned`    | `0640 confluent:confluent` | `640 root:root`        | `640 root:root`     |
| system user file     | `/opt/sync/sub/daemonowned` | `0644 daemon:daemon`       | `644 root:root`        | `644 daemon:daemon` |
| empty directory      | `/opt/sync/emptydir`        | `2750 confluent:confluent` | `700 root:root`        | `2750 root:root`    |

Directories the sync only has to traverse to reach those files. Nothing in the syncfile list refers to them, and
both before and after they must come out exactly as the node had them:

| directory           | node state before sync | before              | after               |
| ------------------- | ---------------------- | ------------------- | ------------------- |
| parent directory (`/opt/sync`)    | `700 root:root`        | `700 root:root`     | `700 root:root`     |
| parent subdirectory (`/opt/sync/sub`) | `750 daemon:daemon`    | `750 daemon:daemon` | `750 daemon:daemon` |

The second table is the point: files were written into the subdirectory, yet neither its mode nor its ownership
moved. In the first table, the system user file keeping `daemon:daemon` while the confluent owned file became
`root:root` confirms the ownership mapping is selective.