### PR TITLE
Honor deployment.useinsecureprotocols for ProxyDHCP boot

### DIFF
--- a/confluent_server/confluent/discovery/protocols/pxe.py
+++ b/confluent_server/confluent/discovery/protocols/pxe.py
@@ -317,11 +317,14 @@ async def proxydhcp(handler, nodeguess):
                 node, ('deployment.*', 'collective.managercandidates'))
             if disco['arch'] is None:
                 continue
+            if disco['arch'] == 'uefi-httpboot':
+                # HTTP boot is offered by the DHCP path, not proxyDHCP
+                continue
             insecuremode = cfd.get(node, {}).get('deployment.useinsecureprotocols',
                 {}).get('value', 'never')
             if not insecuremode:
                 insecuremode = 'never'
-            if insecuremode == 'never' and disco['arch'] != 'uefi-httpboot':
+            if insecuremode == 'never':
                 if not skiplogging:
                     log.log(
                         {'info': 'Boot attempt by {0} detected in insecure mode, but '

--- a/confluent_server/confluent/discovery/protocols/pxe.py
+++ b/confluent_server/confluent/discovery/protocols/pxe.py
@@ -313,10 +313,27 @@ async def proxydhcp(handler, nodeguess):
                                 disco.get('uuid', 'unknown'), disco.get('hwaddr', 'unknown')
                     )})
                 continue
+            cfd = cfg.get_node_attributes(
+                node, ('deployment.*', 'collective.managercandidates'))
+            if disco['arch'] is None:
+                continue
+            insecuremode = cfd.get(node, {}).get('deployment.useinsecureprotocols',
+                {}).get('value', 'never')
+            if not insecuremode:
+                insecuremode = 'never'
+            if insecuremode == 'never' and disco['arch'] != 'uefi-httpboot':
+                if not skiplogging:
+                    log.log(
+                        {'info': 'Boot attempt by {0} detected in insecure mode, but '
+                                'insecure mode is disabled.  Set the attribute '
+                                '`deployment.useinsecureprotocols` to `firmware` or '
+                                '`always` to enable support, or use UEFI HTTP boot '
+                                'with HTTPS.'.format(node)})
+                continue
             profile = None
             if not myipn:
                 myipn = socket.inet_aton(recv)
-                profile, stgprofile = get_deployment_profile(node, cfg)
+                profile, stgprofile = get_deployment_profile(node, cfg, cfd)
                 if profile:
                     log.log({
                         'info': 'Offering proxyDHCP boot from {0} to {1} ({2})'.format(recv, node, client[0])})
@@ -326,7 +343,7 @@ async def proxydhcp(handler, nodeguess):
                     continue
             if opts.get(77, None) == b'iPXE':
                 if not profile:
-                    profile, stgprofile = get_deployment_profile(node, cfg)
+                    profile, stgprofile = get_deployment_profile(node, cfg, cfd)
                 if not profile:
                     log.log({'info': 'No pending profile for {0}, skipping proxyDHCP reply'.format(node)})
                     continue

--- a/confluent_server/confluent/discovery/protocols/pxe.py
+++ b/confluent_server/confluent/discovery/protocols/pxe.py
@@ -715,7 +715,9 @@ async def reply_dhcp4(node, info, packet, cfg, reqview, httpboot, cfd, profile, 
         if not insecuremode:
             insecuremode = 'never'
         if insecuremode == 'never' and not httpboot:
-            if rqtype == 1 and info.get('architecture', None):
+            if (rqtype == 1 and info.get('architecture', None)
+                    and time.time() > ignoremacs.get(info['hwaddr'], 0) + 90):
+                ignoremacs[info['hwaddr']] = time.time()
                 log.log(
                     {'info': 'Boot attempt by {0} detected in insecure mode, but '
                             'insecure mode is disabled.  Set the attribute '

--- a/confluent_server/confluent/discovery/protocols/pxe.py
+++ b/confluent_server/confluent/discovery/protocols/pxe.py
@@ -279,7 +279,6 @@ def relay_proxydhcp(sock, pktq):
     elif disco.get('uuid', None) in uuidmap:
         node = uuidmap[disco['uuid']]
     myipn = myipbypeer.get(data[28:28+hwlen], None)
-    skiplogging = True
     pktq.put_nowait((disco, peer, myipn, idx, recv, node, opts, data))
 
 
@@ -296,6 +295,7 @@ async def proxydhcp(handler, nodeguess):
         try:
             disco, client, myipn, idx, recv, node, opts, data = await pktq.get()
             netaddr = disco['hwaddr']
+            skiplogging = True
             if time.time() > ignoredisco.get(netaddr, 0) + 90:
                 skiplogging = False
                 ignoredisco[netaddr] = time.time()


### PR DESCRIPTION
`reply_dhcp4` refuses to answer a PXE boot request unless `deployment.useinsecureprotocols` is set to `firmware` or
`always`, but the proxyDHCP handler on port 4011 had no such check. A node left at the default of `never` was still
offered a TFTP bootfile and a plain http `boot.ipxe` URL whenever its request arrived on 4011 rather than 67, so the
attribute silently did nothing in ProxyDHCP deployments that run alongside an independent DHCP server.

* Apply the same gate in proxydhcp, with the same UEFI HTTP boot exemption and remediation hint, and ignore requests   whose client architecture could not be determined (those would otherwise reach the iPXE branch without passing the   gate). Node attributes are read once and passed to `get_deployment_profile` instead of being looked up twice.
* Drop UEFI HTTP boot requests on 4011 explicitly. HTTP boot is offered from the DHCP path, and proxyDHCP has no bootfile  branch for it, so such a request fell through with `bootfile` unset or left over from an earlier client.
* Reset `skiplogging` per loop iteration. The reset sat in `relay_proxydhcp` as a dead local, so the flag stayed `False` after the first packet and the 90 second per hwaddr window never re-armed.
* Rate limit the same refusal message in `reply_dhcp4` through the existing `ignoremacs` window. A refused node never gets a reply, so it retries for as long as it is powered on and the hint repeated every few seconds.