### PR TITLE
Await the coroutines in osdeploy local node trust setup

### DIFF
--- a/confluent_server/bin/osdeploy
+++ b/confluent_server/bin/osdeploy
@@ -164,7 +164,7 @@ def init_confluent_myname():
 
 async def local_node_trust_setup():
     init_confluent_myname()
-    allnodes, domain = selfservice.get_cluster_list()
+    allnodes, domain = await selfservice.get_cluster_list()
     myname = collective.get_myname()
     myprincipals = set([myname])
     restorecon = os.path.exists('/usr/sbin/restorecon')
@@ -180,7 +180,7 @@ async def local_node_trust_setup():
         myprincipals.add(addr)
     for pubkey in glob.glob('/etc/ssh/ssh_host_*_key.pub'):
         currpubkey = open(pubkey, 'rb').read()
-        cert = sshutil.sign_host_key(currpubkey, myname, myprincipals)
+        cert = await sshutil.sign_host_key(currpubkey, myname, myprincipals)
         certfile = pubkey.replace('key.pub', 'key-cert.pub')
         neededlines.add('HostCertificate {0}'.format(certfile))
         if os.path.exists(certfile):


### PR DESCRIPTION
local_node_trust_setup() called get_cluster_list() and sign_host_key() without awaiting them, so "osdeploy initialize -l" aborted with "TypeError: cannot unpack non-iterable coroutine object" before doing any work.

Both awaits have to land together: sign_host_key() is called in a loop that unlinks the existing ssh_host_*_key-cert.pub before writing the new one, so fixing only the unpack would delete every host certificate and then fail.