### PR TITLE
Fix FPC/SMM sensor enumeration

### DIFF
--- a/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
@@ -526,8 +526,8 @@ class OEMHandler(generic.OEMHandler):
                 yield await self.immhandler.get_oem_sensor_reading(name,
                                                                    self.ipmicmd)
         elif await self.is_fpc():
-            for name in nextscale.get_sensor_names(self.ipmicmd,
-                                                   self._fpc_variant):
+            async for name in nextscale.get_sensor_names(
+                    self.ipmicmd, self._fpc_variant):
                 yield await nextscale.get_sensor_reading(name, self.ipmicmd,
                                                          self._fpc_variant)
         elif await self.has_ami():

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/nextscale.py
@@ -255,7 +255,7 @@ fpc_sensors = {
 }
 
 
-def get_sensor_names(ipmicmd, size):
+async def get_sensor_names(ipmicmd, size):
     global fpc_sensors
     for name in fpc_sensors:
         if size != 6 and name in ('Fan Power', 'Total Power Capacity',
@@ -272,7 +272,7 @@ def get_sensor_names(ipmicmd, size):
                 elemidx += 1
                 yield '{0} {1}'.format(name, elemidx)
         elif 'elementsfun' in sensor:
-            for elemidx in range(sensor['elementsfun'](ipmicmd, size)):
+            for elemidx in range(await sensor['elementsfun'](ipmicmd, size)):
                 elemidx += 1
                 yield '{0} {1}'.format(name, elemidx)
         elif 'elements' in sensor:
@@ -283,7 +283,7 @@ def get_sensor_names(ipmicmd, size):
             yield name
 
 
-def get_sensor_descriptions(ipmicmd, size):
+async def get_sensor_descriptions(ipmicmd, size):
     global fpc_sensors
     for name in fpc_sensors:
         if size != 6 and name in ('Fan Power', 'Total Power Capacity',
@@ -300,7 +300,7 @@ def get_sensor_descriptions(ipmicmd, size):
                 yield {'name': '{0} {1}'.format(name, elemidx),
                        'type': sensor['type']}
         elif 'elementsfun' in sensor:
-            for elemidx in range(sensor['elementsfun'](ipmicmd, size)):
+            for elemidx in range(await sensor['elementsfun'](ipmicmd, size)):
                 elemidx += 1
                 yield {'name': '{0} {1}'.format(name, elemidx),
                        'type': sensor['type']}


### PR DESCRIPTION
get_sensor_names and get_sensor_descriptions reach get_psu_count for any sensor whose table entry carries elementsfun, and get_psu_count is a coroutine. As plain generators they could not await it, so range() was handed the coroutine object and enumeration died with "'coroutine' object cannot be interpreted as an integer".

Every DW612S has such entries, so nodesensors returned nothing for the enclosure. get_sensor_descriptions was doubly broken: the Lenovo handler already iterated it with async for, which a plain generator cannot satisfy.

Verified against a DW612S SMM (FPC variant 38). Before, descriptions raised at the async for and readings raised partway through enumeration; after, both return all 34 sensors, 19 of which are the PSU entries that never enumerated.