### PR TITLE
Fix ipmi session sharing

### DIFF
--- a/confluent_server/aiohmi/ipmi/console.py
+++ b/confluent_server/aiohmi/ipmi/console.py
@@ -204,6 +204,21 @@ class Console(object):
         if not self.awaitingack:
             await self._sendpendingoutput()
 
+    async def _release_session(self):
+        """Give up this console's claim on the ipmi session
+
+        A console can be sharing one with whatever else is talking to the same
+        bmc, so let go of it rather than closing it.  Clearing the reference
+        first means it does not matter how many exits end up here.
+        """
+        sess = self.ipmi_session
+        if sess is None:
+            return
+        self.ipmi_session = None
+        if sess.sol_handler is not None and sess.sol_handler.__self__ is self:
+            sess.sol_handler = None
+        await sess.logout()
+
     async def close(self):
         """Shut down an SOL session"""
 
@@ -217,6 +232,7 @@ class Console(object):
                 # if underlying ipmi session is not working, then
                 # run with the implicit success
                 pass
+        await self._release_session()
 
     async def send_data(self, data):
         if self.broken:
@@ -320,10 +336,8 @@ class Console(object):
         self.broken = True
         if self.ipmi_session:
             self.ipmi_session.unregister_keepalive(self.keepaliveid)
-            if (self.ipmi_session.sol_handler
-                    and self.ipmi_session.sol_handler.__self__ is self):
-                self.ipmi_session.sol_handler = None
-            self.ipmi_session = None
+            # A console that has given up is finished with the session too
+            await self._release_session()
         if type(error) == dict:
             await self._print_data(error)
         else:

--- a/confluent_server/aiohmi/ipmi/console.py
+++ b/confluent_server/aiohmi/ipmi/console.py
@@ -217,7 +217,12 @@ class Console(object):
         self.ipmi_session = None
         if sess.sol_handler is not None and sess.sol_handler.__self__ is self:
             sess.sol_handler = None
-        await sess.logout()
+        try:
+            await sess.logout()
+        except exc.IpmiException:
+            # A bmc that has stopped answering must not be what makes
+            # closing a console fail, as for the deactivate above
+            pass
 
     async def close(self):
         """Shut down an SOL session"""

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -1987,16 +1987,19 @@ class Session(object):
         self.onlogpayload = None
         self.logging = False
         if self._customkeepalives:
-            for ka in list(self._customkeepalives):
-                # Be thorough and notify parties through their custom
-                # keepalives.  In practice, this *should* be the same, but
-                # if a code somehow makes duplicate SOL handlers,
-                # this would notify all the handlers rather than just the
-                # last one to take ownership
-                if self._customkeepalives[ka][1] is None:
+            # Be thorough and notify parties through their custom
+            # keepalives.  In practice, this *should* be the same, but
+            # if a code somehow makes duplicate SOL handlers,
+            # this would notify all the handlers rather than just the
+            # last one to take ownership
+            # Take the callbacks and give this up first: notifying one can
+            # come back round through here and clear it mid walk
+            callbacks = [ka[1] for ka in self._customkeepalives.values()]
+            self._customkeepalives = None
+            for callback in callbacks:
+                if callback is None:
                     continue
-                await self._customkeepalives[ka][1](
-                    {'error': 'Session Disconnected'})
+                await callback({'error': 'Session Disconnected'})
         self._customkeepalives = None
         if not self.broken:
             self.broken = True

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -390,7 +390,6 @@ class Session(object):
             # Rather than wait until send() to bind, bind now so that we have
             # a port number allocated no matter what
             tmpsocket.bind(('', 0))
-            cls.socketpool[tmpsocket] = 1
         else:
             tmpsocket.bind(server[4])
         iosockets.append(tmpsocket)
@@ -413,6 +412,10 @@ class Session(object):
             initevt = asyncio.Event()
             iothreadwaiters.append(initevt)
             await initevt.wait()
+        if server is None:
+            # Take the count last: one taken for a socket no session ever
+            # received is one nobody is left to give back
+            cls.socketpool[tmpsocket] = 1
         return tmpsocket
 
     def _sync_login(self, response):
@@ -462,7 +465,8 @@ class Session(object):
                 keepalive=True):
         trueself = None
         forbidsock = []
-        sesskey = (bmc, _credkey(userid), _credkey(password), port, kg)
+        sesskey = (bmc, _credkey(userid), _credkey(password), port,
+                   _credkey(kg))
         for res in socket.getaddrinfo(bmc, port, 0, socket.SOCK_DGRAM):
             sockaddr = res[4]
             if ipv6support and res[0] == socket.AF_INET:
@@ -480,7 +484,7 @@ class Session(object):
                     if (self.bmc == bmc
                             and self.userid == _credkey(userid)
                             and self.password == _credkey(password)
-                            and self.kgo == kg):
+                            and _credkey(self.kgo) == _credkey(kg)):
                         trueself = self
                         break
                     # ok, the candidate seems to be working, but does not match

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -550,7 +550,9 @@ class Session(object):
             while self.logging and not self.broken:
                 await Session.wait_for_rsp()
         if self.broken:
-            raise exc.IpmiException(self.errormsg)
+            # Never leave the caller with an exception carrying no reason at all
+            raise exc.IpmiException(
+                self.errormsg or 'Unable to establish a session with the bmc')
 
     async def _mark_broken(self, error=None):
         # since our connection has failed retries
@@ -781,7 +783,7 @@ class Session(object):
                     waiter({'success': True})
                 await self.process_pktqueue()
                 if _monotonic_time() > alltimeout:
-                    await self._mark_broken()
+                    await self._mark_broken('Session no longer connected')
                     raise exc.IpmiException('Session no longer connected')
                 await WAITING_SESSIONS.acquire()
                 try:
@@ -815,7 +817,7 @@ class Session(object):
         if not self.logged:
             if (self.logoutexpiry is not None
                     and _monotonic_time() > self.logoutexpiry):
-                await self._mark_broken()
+                await self._mark_broken('Session no longer connected')
             raise exc.IpmiException('Session no longer connected')
         await self.atomicop.acquire()
         try:
@@ -1372,7 +1374,7 @@ class Session(object):
                 else:
                     await self.logout()
         except exc.IpmiException:
-            await self._mark_broken()
+            await self._mark_broken('Session keepalive failed')
 
     async def process_pktqueue(self):
         while self.pktqueue:
@@ -1810,7 +1812,7 @@ class Session(object):
                 if self.ipmicallback:
                     await self.ipmicallback(response)
                 self.nowait = False
-                await self._mark_broken()
+                await self._mark_broken('timeout')
                 return
             else:
                 self.maxtimeout = 2
@@ -1847,7 +1849,7 @@ class Session(object):
                 if self.ipmicallback:
                     await self.ipmicallback(response)
                 self.nowait = False
-                await self._mark_broken()
+                await self._mark_broken('timeout')
                 return
         else:  # in IPMI case, the only recourse is to act as if the packet is
             # idempotent.  SOL has more sophisticated retry handling

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -422,6 +422,24 @@ class Session(object):
             KEEPALIVE_SESSIONS.release()
         return not session.broken
 
+    @classmethod
+    async def _await_login(cls, session):
+        """Wait out a login that another caller has already started
+
+        A session handed out mid login is not usable yet, and the caller
+        receiving it cannot tell, so wait and give it the same answer as the
+        caller that built it.
+        """
+        while not (session.logged or session.broken):
+            # A ceiling, not a wait: with nothing registered to wait for,
+            # wait_for_rsp returns at once.  Traffic still ends it early.
+            await cls.wait_for_rsp(1)
+        if session.broken:
+            raise exc.IpmiException(
+                getattr(session, 'errormsg', None)
+                or 'Unable to establish a session with the bmc')
+        return session
+
     async def __new__(cls,
                 bmc,
                 userid,
@@ -432,6 +450,7 @@ class Session(object):
                 keepalive=True):
         trueself = None
         forbidsock = []
+        sesskey = (bmc, userid, password, port, kg)
         for res in socket.getaddrinfo(bmc, port, 0, socket.SOCK_DGRAM):
             sockaddr = res[4]
             if ipv6support and res[0] == socket.AF_INET:
@@ -460,18 +479,23 @@ class Session(object):
                     # id, however it's easier this way
                     forbidsock.append(self.socket)
             if trueself:
-                return trueself
-            i = cls.initting_sessions.get(
-                (bmc, userid, password, port, kg), False)
+                return await cls._await_login(trueself)
+            i = cls.initting_sessions.get(sesskey, False)
             if i:
-                i.initialized = True
-                i.logging = True
-                return i
+                return await cls._await_login(i)
             self = super().__new__(cls)
             self.forbidsock = forbidsock
-            await self.__init__(
-                bmc, userid, password, port, kg, privlevel, keepalive)
-            cls.initting_sessions[(bmc, userid, password, port, kg)] = self
+            # Register before establishing, not after: this is where a caller
+            # asking for a session already on its way finds it, and leaving it
+            # to the end left the whole login uncovered
+            cls.initting_sessions[sesskey] = self
+            try:
+                await self.__init__(
+                    bmc, userid, password, port, kg, privlevel, keepalive)
+            finally:
+                # The only removal, and it has to happen whether the login
+                # worked or not, or the entry outlives the session
+                cls.initting_sessions.pop(sesskey, None)
             return self
 
     async def __init__(self,
@@ -569,12 +593,6 @@ class Session(object):
             Session.waiting_sessions.pop(self, None)
         finally:
             WAITING_SESSIONS.release()
-        try:
-            del Session.initting_sessions[(self.bmc, self.userid,
-                                           self.password, self.port,
-                                           self.kgo)]
-        except KeyError:
-            pass
         await self.logout(False)
         # self.logging = False
         self.errormsg = error
@@ -1890,12 +1908,6 @@ class Session(object):
                         Session.bmc_handlers[sockaddr] = {}
                     Session.bmc_handlers[sockaddr][myport] = self
                     _io_sendto(self.socket, self.netpacket, sockaddr)
-                try:
-                    del Session.initting_sessions[(self.bmc, self.userid,
-                                                   self.password, self.port,
-                                                   self.kgo)]
-                except KeyError:
-                    pass
             except socket.gaierror:
                 raise exc.IpmiException(
                     "Unable to transmit to specified address")

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -251,6 +251,18 @@ async def _poller(timeout=0):
     return sessionqueue
 
 
+def _credkey(value):
+    """A credential in the form a session keeps it, so callers can be compared
+
+    A session encodes what it was given, while the checks for sharing one are
+    built from whatever the caller passed.  Put both through here.
+    """
+    try:
+        return value.encode('utf-8')
+    except AttributeError:
+        return value
+
+
 def _aespad(data):
     """ipmi demands a certain pad scheme, per table 13-20 AES-CBC encrypted
 
@@ -450,7 +462,7 @@ class Session(object):
                 keepalive=True):
         trueself = None
         forbidsock = []
-        sesskey = (bmc, userid, password, port, kg)
+        sesskey = (bmc, _credkey(userid), _credkey(password), port, kg)
         for res in socket.getaddrinfo(bmc, port, 0, socket.SOCK_DGRAM):
             sockaddr = res[4]
             if ipv6support and res[0] == socket.AF_INET:
@@ -466,8 +478,8 @@ class Session(object):
                         del cls.bmc_handlers[sockaddr][portself[0]]
                         continue
                     if (self.bmc == bmc
-                            and self.userid == userid
-                            and self.password == password
+                            and self.userid == _credkey(userid)
+                            and self.password == _credkey(password)
                             and self.kgo == kg):
                         trueself = self
                         break

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -532,6 +532,9 @@ class Session(object):
         self.servermode = False
         self.initialized = True
         self.cleaningup = False
+        # Whether this session still holds the socket pool count it took.
+        # Set before anything can fail, so releasing is safe either way.
+        self._socketclaimed = False
         self.lastpayload = None
         self._customkeepalives = None
         # queue of events denoting line to run a cmd
@@ -567,6 +570,7 @@ class Session(object):
         await self.socketchecking.acquire()
         try:
             self.socket = await self._assignsocket(forbiddensockets=self.forbidsock)
+            self._socketclaimed = True
         finally:
             self.socketchecking.release()
         await self.login()
@@ -577,6 +581,18 @@ class Session(object):
             # Never leave the caller with an exception carrying no reason at all
             raise exc.IpmiException(
                 self.errormsg or 'Unable to establish a session with the bmc')
+
+    def _release_socket(self):
+        """Give back the socket pool count this session took, exactly once
+
+        More than one path ended a session and decremented, so the count fell
+        below zero.  _assignsocket picks the least used socket and refuses one
+        at MAX_BMCS_PER_SOCKET, and both read this number.
+        """
+        if not self._socketclaimed:
+            return
+        self._socketclaimed = False
+        self.socketpool[self.socket] -= 1
 
     async def _mark_broken(self, error=None):
         # since our connection has failed retries
@@ -598,8 +614,7 @@ class Session(object):
         self.errormsg = error
         if not self.broken:
             self.broken = True
-            if self.socket:
-                self.socketpool[self.socket] -= 1
+            self._release_socket()
         while self.logonwaiters:
             waiter = self.logonwaiters.pop()
             try:
@@ -1961,7 +1976,6 @@ class Session(object):
                     {'error': 'Session Disconnected'})
         self._customkeepalives = None
         if not self.broken:
-            self.socketpool[self.socket] -= 1
             self.broken = True
             # since this session is broken, remove it from the handler list
             # This allows constructor to create a new, functional object to
@@ -1974,7 +1988,7 @@ class Session(object):
                     if Session.bmc_handlers[sockaddr] == {}:
                         del Session.bmc_handlers[sockaddr]
         self.nowait = False
-        self.socketpool[self.socket] -= 1
+        self._release_socket()
         return {'success': True}
 
 

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -479,10 +479,15 @@ class Session(object):
                     # id, however it's easier this way
                     forbidsock.append(self.socket)
             if trueself:
-                return await cls._await_login(trueself)
+                await cls._await_login(trueself)
+                # Count the caller only once it is really getting the session
+                trueself.users += 1
+                return trueself
             i = cls.initting_sessions.get(sesskey, False)
             if i:
-                return await cls._await_login(i)
+                await cls._await_login(i)
+                i.users += 1
+                return i
             self = super().__new__(cls)
             self.forbidsock = forbidsock
             # Register before establishing, not after: this is where a caller
@@ -531,6 +536,8 @@ class Session(object):
         # Whether this session still holds the socket pool count it took.
         # Set before anything can fail, so releasing is safe either way.
         self._socketclaimed = False
+        # How many callers hold this session; the last one out closes it
+        self.users = 1
         self.lastpayload = None
         self._customkeepalives = None
         # queue of events denoting line to run a cmd
@@ -1936,7 +1943,15 @@ class Session(object):
                 WAITING_SESSIONS.release()
 
     async def logout(self, sessionok=True):
-
+        if (sessionok and self.users > 1
+                and not self.broken and not self.cleaningup):
+            # A caller finished with a working session gives up its claim and
+            # leaves it to whoever else holds it; closing it here would hand
+            # them one that answers as though it had been lost.  sessionok is
+            # false when it is no longer usable, and then it comes down anyway.
+            self.users -= 1
+            return {'success': True}
+        self.users = 0
         if self.cleaningup:
             self.nowait = True
         if self.logged:

--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -506,10 +506,6 @@ class Session(object):
                  kg=None,
                  privlevel=None,
                  keepalive=True):
-        if hasattr(self, 'initialized'):
-            # new found an existing session, do not corrupt it
-            while self.logging and not self.broken:
-                await Session.wait_for_rsp()
         self.awaitingresponse = False
         self.lastresponse = None
         self.atomicop = asyncio.Lock()


### PR DESCRIPTION
# Fix ipmi session sharing

Eight commits against the ipmi session layer, in `aiohmi/ipmi/private/session.py`
and `aiohmi/ipmi/console.py`. Found while checking an unrelated branch for
regressions against a Lenovo XCC2, and independent of it: this branch touches no
other file.

## What was wrong

**The register of sessions being established was never emptied, so callers
adopted dead sessions.** `initting_sessions` exists so a caller can share a
session another is still establishing. The entry was added only once the login had
finished, and the two places that removed it keyed on the credentials a session
stores *encoded* against a register keyed on the caller's strings, so they never
matched. The entry therefore outlived its session, and every later caller was
handed a session that had already gone: open a command session, close it, open
another, and the second one fails with `Session no longer connected`.

**A command session and a console session opened at the same time both broke.**
With the login itself uncovered by the register, two callers each built a session,
both on the socket the other had not claimed yet. Replies route by bmc address and
local port, so only the last to transmit was ever answered and the other waited
for replies delivered to its neighbour. This is what the console session "failing
about one attempt in three" was.

**The socket pool count went negative.** `logout` decremented it twice and
`_mark_broken` again, so one session took one count and gave back two. Both of
`_assignsocket`'s decisions read that number: it picks the least used socket, so
the most negative one wins every time, and it refuses a socket at
`MAX_BMCS_PER_SOCKET`, which a count counting downwards never reaches.

**Once sessions really are shared, one holder's `logout` closed the session for
the others**, leaving them holding one that answered as though it had been lost.
Holders are counted now, and a console gives its claim back on both of its exits,
which it previously never did.

Alongside those: a session that failed raised with no message at all, the check
for reusing a live session compared encoded credentials against the caller's
strings so it never matched, and `__init__` carried a guard that could not fire.

## What this is not

The registration order and the dead guard are regressions from the port to
asyncio (pyghmi > aiohmi). The credential comparison, the double decrement and the missing holder
count are the same in upstream pyghmi.

## Reproducing

Three of these can be shown with a bmc.
Run from the root with `BMC` pointing at the bmc or at a forwarded port for it:

```sh
export BMC=127.0.0.1 BMCUSER=admin BMCPASS=...
```

**1. A closed session is handed to the next caller.**

```sh
python3 - <<'EOF'
import asyncio, os, sys
sys.path.insert(0, 'confluent_server')
from aiohmi.ipmi import command
from aiohmi.ipmi.private.session import Session

async def main():
    kw = dict(bmc=os.environ['BMC'], userid=os.environ['BMCUSER'],
              password=os.environ['BMCPASS'])
    first = await command.Command.create(**kw)
    await first.ipmi_session.logout()
    print('register entries after closing it:', len(Session.initting_sessions))
    second = await command.Command.create(**kw)
    try:
        print('a fresh command still works:', await second.get_power())
    except Exception as e:
        print('a fresh command still works: no, {0}'.format(e))

asyncio.run(main())
EOF
```

```
before:  register entries after closing it: 1
         a fresh command still works: no, Session no longer connected
after:   register entries after closing it: 0
         a fresh command still works: {'powerstate': 'on'}
```

**2. The socket pool count.**

```sh
python3 - <<'EOF'
import asyncio, os, sys
sys.path.insert(0, 'confluent_server')
from aiohmi.ipmi import command
from aiohmi.ipmi.private.session import Session

async def main():
    cmds = []
    for _ in range(3):
        cmds.append(await command.Command.create(
            bmc=os.environ['BMC'], userid=os.environ['BMCUSER'],
            password=os.environ['BMCPASS']))
    for c in cmds:
        await c.ipmi_session.logout()
    print('socket pool after closing them:', sorted(Session.socketpool.values()))

asyncio.run(main())
EOF
```

```
before:  socket pool after closing them: [-3]
after:   socket pool after closing them: [0]
```

**3. A command and a console opened together.**

```sh
python3 - <<'EOF'
import asyncio, os, sys
sys.path.insert(0, 'confluent_server')
from aiohmi.ipmi import command, console

async def sink(data):
    return None

async def main():
    kw = dict(bmc=os.environ['BMC'], userid=os.environ['BMCUSER'],
              password=os.environ['BMCPASS'])
    con = console.Console(iohandler=sink, force=True, **kw)
    cmd, _ = await asyncio.gather(command.Command.create(**kw), con.connect())
    print('one session shared:', cmd.ipmi_session is con.ipmi_session)
    for who, sess in (('command', cmd.ipmi_session), ('console', con.ipmi_session)):
        try:
            await sess.raw_command(netfn=6, command=1)
            print('{0} session works: yes'.format(who))
        except Exception as e:
            print('{0} session works: no, {1}'.format(who, e))

asyncio.run(main())
EOF
```

```
before:  one session shared: False
         command session works: yes
         console session works: no, Session no longer connected
after:   one session shared: True
         command session works: yes
         console session works: yes
```

The rest are harder to trigger on demand and were checked by hand rather than by
a snippet: the holder count needs a console and a command torn down in a
particular order, and the re-entrant `logout` needs a second keepalive of the kind
the XCC oem handler registers.

## Also checked

Against the same Lenovo XCC2 through the daemon, before and after, over both the
ipmi and redfish transports: power, health, 309 ipmi sensors, inventory,
`nodeconfig bmc`, event log, and two SOL attaches reaching a login prompt. Same
output, same exit codes, no tracebacks either side.

Two things could not be verified on that hardware. `kg` normalisation is covered
by a unit check rather than a bmc configured for it. And the claim that the daemon
holds fewer sessions overall could not be isolated, because the bmc's session
table is shared and its timeout is longer than the measurement window; the
per-session evidence above is from the library, where every session is accounted
for.