### PR TITLE
Various fixes and features for AMI MegaRAC and OpenBMC BMCs

### DIFF
--- a/confluent_client/bin/nodeconsole
+++ b/confluent_client/bin/nodeconsole
@@ -489,6 +489,10 @@ def direct_console():
     global oldfl
     if console_direct_mode:
         return False
+    if not sys.stdin.isatty():
+        # Nothing to put in raw mode, which is fine for output only usage such
+        # as reporting an error from a screenshot request
+        return False
     console_direct_mode = True
     oldtcattr = termios.tcgetattr(sys.stdin.fileno())
     oldfl = fcntl.fcntl(sys.stdin.fileno(), fcntl.F_GETFL)
@@ -907,7 +911,9 @@ async def do_screenshot():
                         if len(imgdata) < 32: # We were subjected to error
                             errorstr = 'Unable to get screenshot'
                     if errorstr or imgdata:
-                        imgdata = base64.b64decode(imgdata)
+                        # A node may report an error with no image at all, and
+                        # there is nothing to decode in that case
+                        imgdata = base64.b64decode(imgdata) if imgdata else None
                         draw_node(node, imgdata, errorstr, firstnodename, cwidth, cheight)
         urlbynode = {}
         for node in vnconly:
@@ -1086,6 +1092,10 @@ def draw_node(node, imgdata, errorstr, firstnodename, cwidth, cheight):
     sys.stdout.flush()
 
 if options.screenshot or options.video:
+    if not sys.stdout.isatty():
+        sys.stderr.write(
+            'Screenshot and video rendering need a terminal to draw in\n')
+        sys.exit(1)
     streaming = options.video
     try:
         cursor_hide()

--- a/confluent_client/bin/nodedefine
+++ b/confluent_client/bin/nodedefine
@@ -49,6 +49,11 @@ async def main():
     exitcode = 0
     attribs = {'name': noderange}
     for arg in args[1:]:
+        if '=' not in arg:
+            sys.stderr.write(
+                'Attributes must be given as attribute=value, got "{0}"\n'.format(
+                    arg))
+            sys.exit(1)
         key, val = arg.split('=', 1)
         attribs[key] = val
     async for r in session.create('/noderange/', attribs):

--- a/confluent_client/bin/nodefirmware
+++ b/confluent_client/bin/nodefirmware
@@ -99,7 +99,7 @@ def get_update_progress(session, url):
     for res in session.read(url):
         status = res.get('phase', 'error')
         percent = res.get('progress', None)
-        detail = res.get('detail', repr(res)),
+        detail = res.get('detail', repr(res))
         if status == 'error':
             text = 'error!'
         else:
@@ -143,6 +143,11 @@ def update_firmware(session, filename):
                 pass
     for res in session.create(resource, upargs):
         if 'created' not in res:
+            if not res.get('databynode', None):
+                # A failure that is not attributed to any node still has to be
+                # reported, or the command looks like it quietly did nothing
+                exitcode |= client.printerror(res)
+                continue
             for nodename in res.get('databynode', ()):
                 output.set_output(nodename, 'error!')
                 noderrs[nodename] = res['databynode'][nodename].get(
@@ -196,7 +201,10 @@ def show_firmware(session):
     if not nodes_matched:
         sys.stderr.write('No matching nodes for noderange "{0}"\n'.format(noderange))
     elif not firmware_shown and not exitcode:
-        argparser.print_help()
+        # Asking about firmware the target does not describe is a legitimate
+        # question with an empty answer, not a mistake in how it was asked
+        sys.stderr.write('No firmware reported for "{0}"\n'.format(
+            ','.join(components)))
 
 
 try:
@@ -204,12 +212,11 @@ try:
     if querystatus:
         for res in session.read(
                 '/noderange/{0}/inventory/firmware/updatestatus'.format(noderange)):
+            exitcode |= client.printerror(res)
             for node in res.get('databynode', {}):
                 currstat = res['databynode'][node].get('status', None)
                 if currstat:
                     print('{}: {}'.format(node, currstat))
-                else:
-                    print(repr(res))
     elif upfile is None:
         show_firmware(session)
     else:

--- a/confluent_client/bin/nodefirmware
+++ b/confluent_client/bin/nodefirmware
@@ -56,7 +56,7 @@ components = ['all']
 
 argparser = optparse.OptionParser(
     usage="Usage: "
-          "%prog <noderange> [list][updatestatus][update [--backup] "
+          "%prog <noderange> [list][updatestatus][updatetypes][update [--backup] "
           "[--parameterfile <file>] <file>]|[<components>]")
 argparser.add_option('-b', '--backup', action='store_true',
                      help='Target a backup bank rather than primary')
@@ -71,6 +71,7 @@ argparser.add_option('-m', '--maxnodes', type='int',
 (options, args) = argparser.parse_args()
 upfile = None
 querystatus = False
+querytypes = False
 try:
     noderange = args[0]
     if len(args) > 1:
@@ -82,6 +83,8 @@ try:
                 comps = args[2:]
             elif args[1] == 'updatestatus':
                 querystatus = True
+            elif args[1] == 'updatetypes':
+                querytypes = True
             else:
                 comps = args[1:]
             components = []
@@ -207,6 +210,17 @@ def show_firmware(session):
             ','.join(components)))
 
 
+def show_update_types(session):
+    global exitcode
+    for res in session.read(
+            '/noderange/{0}/inventory/firmware/updatetypes'.format(noderange)):
+        exitcode |= client.printerror(res)
+        for node in res.get('databynode', {}):
+            types = res['databynode'][node].get('types', None)
+            if types:
+                print('{0}: {1}'.format(node, ','.join(types)))
+
+
 try:
     session = client.Command()
     if querystatus:
@@ -217,6 +231,8 @@ try:
                 currstat = res['databynode'][node].get('status', None)
                 if currstat:
                     print('{}: {}'.format(node, currstat))
+    elif querytypes:
+        show_update_types(session)
     elif upfile is None:
         show_firmware(session)
     else:

--- a/confluent_client/bin/nodefirmware
+++ b/confluent_client/bin/nodefirmware
@@ -56,11 +56,14 @@ components = ['all']
 
 argparser = optparse.OptionParser(
     usage="Usage: "
-          "%prog <noderange> [list][updatestatus][update [--backup <file>]]|[<components>]")
+          "%prog <noderange> [list][updatestatus][update [--backup] "
+          "[--parameterfile <file>] <file>]|[<components>]")
 argparser.add_option('-b', '--backup', action='store_true',
                      help='Target a backup bank rather than primary')
 argparser.add_option('-p', '--parameterfile', type='string',
-                     help='When updating, use the specified parameter file')
+                     help='When updating, use the specified parameter file; see '
+                          'nodefirmware(8), some platforms need it to say what '
+                          'kind of firmware the image holds')
 argparser.add_option('-m', '--maxnodes', type='int',
                      help='When updating, prompt if more than the specified '
                           'number of servers will be affected')

--- a/confluent_client/bin/nodeinventory
+++ b/confluent_client/bin/nodeinventory
@@ -38,6 +38,8 @@ if sys.version_info[0] < 3:
     sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 filters = []
+wanted = []
+matched = False
 
 
 def pretty(text):
@@ -123,6 +125,8 @@ if len(args) > 1:
         url = '/noderange/{0}/inventory/hardware/all/system'
         for rawarg in args:
             for arg in rawarg.split(','):
+                if arg in ('serial', 'model', 'uuid', 'mac'):
+                    wanted.append(arg)
                 if arg == 'serial':
                     filters.append(re.compile('serial number'))
                 elif arg == 'model':
@@ -203,6 +207,7 @@ try:
                             continue
                     if info[datum] is None:
                         continue
+                    matched = True
                     if options.json:
                         if node not in databynode:
                             databynode[node] = {}
@@ -212,6 +217,11 @@ try:
                         print(u'{0}: {1} {2}: {3}'.format(node, prefix,
                                                          pretty(datum),
                                                          info[datum]))
+    if filters and not matched and not options.store:
+        # An inventory that does not describe what was asked for is a valid
+        # answer, but saying nothing at all leaves the caller guessing
+        sys.stderr.write('No {0} reported for "{1}"\n'.format(
+            '/'.join(wanted) if wanted else 'matching inventory', noderange))
     if options.json:
         print(json.dumps(databynode, sort_keys=True, indent=4,
                          separators=(',', ': ')))

--- a/confluent_client/bin/nodelicense
+++ b/confluent_client/bin/nodelicense
@@ -119,6 +119,7 @@ def show_licenses(session):
     for res in session.read(
             '/noderange/{0}/configuration/management_controller/licenses/'
             'all'.format(noderange)):
+        exitcode |= client.printerror(res)
         for node in res.get('databynode', {}):
             for license in res['databynode'][node].get('License', []):
                 msg = '{0}: {1}'.format(node, license.get('feature',

--- a/confluent_client/bin/nodesensors
+++ b/confluent_client/bin/nodesensors
@@ -144,7 +144,10 @@ def sensorpass(showout=True, appendtime=False):
                             showval = u' {0} '.format(floatformat(sensedata['value']))
                         else:
                             showval = u' {0} '.format(sensedata.get('value', ''))
-                        if sensedata.get('units', None) not in (None, u''):
+                        # A discrete sensor has no reading for a unit to apply
+                        # to, and printing the unit on its own says nothing
+                        if (showval
+                                and sensedata.get('units', None) not in (None, u'')):
                             showval += sensedata['units']
                         if sensedata.get('health', 'ok') != 'ok':
                             datadescription = [sensedata['health']]

--- a/confluent_client/bin/nodestorage
+++ b/confluent_client/bin/nodestorage
@@ -244,6 +244,8 @@ def main():
             sys.stdout.write('Aborting\n')
             sys.exit(1)
     handler(noderange, options, args[2:])
+    # The handlers record failures in exitcode, so let a caller see them
+    sys.exit(exitcode)
 
 
 if __name__ == '__main__':

--- a/confluent_client/bin/nodesupport
+++ b/confluent_client/bin/nodesupport
@@ -76,6 +76,11 @@ def download_servicedata(noderange, media, options):
     session.stop_if_noderange_over(noderange, options.maxnodes)
     for res in session.create(resource, upargs):
         if 'created' not in res:
+            if not res.get('databynode', None):
+                # A failure that is not attributed to any node still has to be
+                # reported, or the command looks like it quietly did nothing
+                printerror(res)
+                continue
             for nodename in res.get('databynode', ()):
                 output.set_output(nodename, 'error!')
                 noderrs[nodename] = res['databynode'][nodename].get(
@@ -148,5 +153,9 @@ def main():
         argparser.print_help()
         sys.exit(1)
     handler(noderange, media, options)
+    # The handlers record failures in exitcode, so let a caller see them
+    sys.exit(exitcode)
+
+
 if __name__ == '__main__':
     main()

--- a/confluent_client/confluent/logreader.py
+++ b/confluent_client/confluent/logreader.py
@@ -175,6 +175,10 @@ class LogReplay(object):
 
 
 def _replay_to_console(txtfile, binfile):
+    if not sys.stdin.isatty():
+        # Interactive replay needs a terminal to put in raw mode and to take
+        # navigation keys from, so without one just write the log out
+        return dump_to_console(txtfile)
     replay = LogReplay(txtfile, binfile)
     oldtcattr = termios.tcgetattr(sys.stdin.fileno())
     tty.setraw(sys.stdin.fileno())

--- a/confluent_client/doc/man/nodefirmware.ronn
+++ b/confluent_client/doc/man/nodefirmware.ronn
@@ -3,7 +3,7 @@ nodefirmware(8) -- Report firmware information on confluent nodes
 
 ## SYNOPSIS
 
-`nodefirmware <noderange> [list][updatestatus][update [--backup] [--parameterfile <file>] <file>]|[<components>]`
+`nodefirmware <noderange> [list][updatestatus][updatetypes][update [--backup] [--parameterfile <file>] <file>]|[<components>]`
 
 ## DESCRIPTION
 
@@ -19,6 +19,10 @@ the FPGA version where applicable).
 
 The updatestatus argument will describe the state of firmware updates on the
 nodes.
+
+The updatetypes argument will name the kinds of firmware image the platform has
+to be told about, for use in a parameter file.  Platforms that read the kind of
+firmware from the image itself have none to name and say so.
 
 In the update form, it accepts a single file and attempts to update it using
 the out of band facilities.  Firmware updates can end in one of three states:
@@ -57,12 +61,20 @@ holds, and refuse the update rather than guess.  On an AMI MegaRAC that is an
 
     {"OemParameters": {"ImageType": "BIOS"}}
 
-Attempting the update without it names the types the platform accepts in the
-error, so there is no need to look them up first.  The value is checked against
-the same list before anything is uploaded, so a name the platform does not accept
-is refused rather than sent.
+`nodefirmware <noderange> updatetypes` names the accepted types without
+attempting an update.  The value is also checked against the same list before
+anything is uploaded, so a name the platform does not accept is refused rather
+than sent.
 
 ## EXAMPLES
+
+* Ask what kinds of firmware image a node has to be told about:
+`# nodefirmware n1 updatetypes`  
+`n1: BMC,BIOS,MB_CPLD,SCM_CPLD,BPB_CPLD,HPM_BMC,HPM_BIOS,HPM_SCP,HPM_BIOS2`  
+
+* Update the BIOS on a platform that has to be told:
+`# echo '{"OemParameters": {"ImageType": "BIOS"}}' > /tmp/bios.json`  
+`# nodefirmware n1 update -p /tmp/bios.json /tmp/image.bin`  
 
 * Pull firmware from a node:
 `# nodefirmware r1`  

--- a/confluent_client/doc/man/nodefirmware.ronn
+++ b/confluent_client/doc/man/nodefirmware.ronn
@@ -3,7 +3,7 @@ nodefirmware(8) -- Report firmware information on confluent nodes
 
 ## SYNOPSIS
 
-`nodefirmware <noderange> [list][updatestatus][update [--backup <file>]]|[<components>]`
+`nodefirmware <noderange> [list][updatestatus][update [--backup] [--parameterfile <file>] <file>]|[<components>]`
 
 ## DESCRIPTION
 
@@ -37,10 +37,30 @@ the out of band facilities.  Firmware updates can end in one of three states:
   be affected  
 
 * `-p PARAMETERFILE`, `--parameterfile=PARAMETERFILE`:
-  For updating, a parameter file to provide along with the update payload
+  For updating, a parameter file to provide along with the update payload.  See
+  PARAMETER FILE below
 
 * `-h`, `--help`:
   Show help message and exit    
+
+## PARAMETER FILE
+
+The parameter file given with `-p` holds JSON that is sent alongside the image.
+Its keys are the parts a Redfish multipart update accepts, so `UpdateParameters`
+for the standard fields and `OemParameters` for whatever a vendor asks for on top
+of them.  Without one, an update names no targets, which means "whatever this
+image is for", and that is what most platforms want.
+
+Some platforms will not take an image without being told what kind of firmware it
+holds, and refuse the update rather than guess.  On an AMI MegaRAC that is an
+`ImageType` under `OemParameters`:
+
+    {"OemParameters": {"ImageType": "BIOS"}}
+
+Attempting the update without it names the types the platform accepts in the
+error, so there is no need to look them up first.  The value is checked against
+the same list before anything is uploaded, so a name the platform does not accept
+is refused rather than sent.
 
 ## EXAMPLES
 

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -255,8 +255,12 @@ class Command(object):
             self._oem = await genericoem.OEMHandler.create(None, None)
             self._oemknown = True
             return
-        self._oem, self._oemknown = await get_oem_handler(await self._get_device_id(),
-                                                    self)
+        self._oem, _ = await get_oem_handler(await self._get_device_id(), self)
+        # Settling for the generic handler is an answer too.  The device id
+        # cannot change within a session, so asking again only buys a round
+        # trip to the bmc and a fresh handler with none of the state the last
+        # one had cached.
+        self._oemknown = True
 
     async def get_bootdev(self):
         """Get current boot device override information.

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -1935,6 +1935,11 @@ class Command(object):
         await self.raw_command(netfn=0x06, command=0x45, data=data, timeout=2)
         return True
 
+    # Parameter out of range, requested record not present, and invalid data
+    # field: the three ways a bmc says the user slot asked about is not one it
+    # has.  Anything else it answers is about the bmc, not about the slot.
+    _absentusercodes = (0xc9, 0xcb, 0xcc)
+
     async def get_user_name(self, uid, return_none_on_error=True):
         """Get user name
 
@@ -1946,11 +1951,11 @@ class Command(object):
             response = await self.raw_command(netfn=0x06, command=0x46,
                                               data=(uid,))
         except exc.IpmiException as ie:
-            # A completion code is the bmc answering about this slot, and some
-            # leave a slot in a state where that answer is an error rather than
-            # an empty name.  A timeout or a lost session is not an answer, and
-            # reading one as an empty slot would quietly shorten a user list.
-            if return_none_on_error and 0 < ie.ipmicode <= 0xff:
+            # Only the codes that say there is no such slot to describe.  A
+            # timeout, a lost session, or a bmc that is merely busy or still
+            # starting up is not an answer about the slot, and reading one as
+            # an empty slot would quietly shorten a user list.
+            if return_none_on_error and ie.ipmicode in self._absentusercodes:
                 return None
             raise
         name = None

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -825,14 +825,19 @@ class Command(object):
         one byte, return the int value
         """
         fetchcmd = bytearray((channel, param, 0, 0))
-        try:
-            fetched = await self.oldraw_command(0xc, 2, data=fetchcmd)
-        except exc.IpmiException as ie:
-            if ie.ipmicode == 0x80:
-                return None
-            raise
+        fetched = await self.oldraw_command(0xc, 2, data=fetchcmd)
+        # A bmc without the parameter says so in the completion code and sends
+        # no data at all, so the code has to be read before the payload is.
+        # oldraw_command reports the code rather than raising on it, which is
+        # why this cannot be done by catching something.
+        if fetched['code'] in (0x80, 0xc9):
+            # parameter not supported, and parameter out of range
+            return None
+        if fetched['code']:
+            raise exc.IpmiException(util.get_ipmi_error(fetched),
+                                    fetched['code'])
         fetchdata = fetched['data']
-        if bytearray(fetchdata)[0] != 17:
+        if not fetchdata or bytearray(fetchdata)[0] != 17:
             return None
         if param == 0x14:
             vlaninfo = struct.unpack('<H', fetchdata[1:])[0]
@@ -1066,8 +1071,12 @@ class Command(object):
             3: 'BIOS',
             4: 'Other',
         }
-        retdata['ipv4_configuration'] = v4cfgmethods[await self._fetch_lancfg_param(
-            channel, 4)]
+        v4cfgmethod = await self._fetch_lancfg_param(channel, 4)
+        if v4cfgmethod is None:
+            retdata['ipv4_configuration'] = None
+        else:
+            retdata['ipv4_configuration'] = v4cfgmethods.get(
+                v4cfgmethod, 'Unknown ({0})'.format(v4cfgmethod))
         retdata['mac_address'] = await self._fetch_lancfg_param(channel, 5)
         retdata['ipv4_gateway'] = await self._fetch_lancfg_param(channel, 12)
         retdata['ipv4_backup_gateway'] = await self._fetch_lancfg_param(channel, 14)

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -1388,7 +1388,13 @@ class Command(object):
         except exc.UnsupportedFunctionality:
             # Use the DCMI MCI field as a fallback, since it's the closest
             # thing in the IPMI Spec for this
-            return await self.get_mci()
+            try:
+                return await self.get_mci()
+            except exc.UnsupportedFunctionality:
+                # With neither an oem command nor DCMI there is nowhere left to
+                # look, and the caller asked about a hostname rather than DCMI
+                raise exc.UnsupportedFunctionality(
+                    'The bmc hostname is not reported by this platform')
 
     async def get_mci(self):
         """Set the management controller identifier.
@@ -1415,7 +1421,11 @@ class Command(object):
         try:
             return await self._oem.set_hostname(hostname)
         except exc.UnsupportedFunctionality:
-            return await self.set_mci(hostname)
+            try:
+                return await self.set_mci(hostname)
+            except exc.UnsupportedFunctionality:
+                raise exc.UnsupportedFunctionality(
+                    'The bmc hostname cannot be set on this platform')
 
     async def set_mci(self, mci):
         """Set the management controller identifier.
@@ -1449,9 +1459,26 @@ class Command(object):
             return await self._oem.set_asset_tag(tag)
         return await self._chunkwise_dcmi_set(8, tag)
 
+    async def _dcmi_command(self, command, data):
+        """Issue a DCMI command, telling a bmc without DCMI apart from a fault.
+
+        A bmc that does not implement the DCMI group at all rejects the command
+        outright, which is not the same thing as the request having been bad, and
+        the caller can offer something else or say plainly that the platform
+        cannot do it.
+        """
+        try:
+            return await self.raw_command(netfn=0x2c, command=command,
+                                          data=data)
+        except exc.IpmiException as ie:
+            # invalid command, and command disabled or unavailable
+            if ie.ipmicode in (0xc1, 0xd6):
+                raise exc.UnsupportedFunctionality(
+                    'This platform does not support the DCMI commands')
+            raise
+
     async def _chunkwise_dcmi_fetch(self, command):
-        szdata = await self.raw_command(
-            netfn=0x2c, command=command, data=(0xdc, 0, 0))
+        szdata = await self._dcmi_command(command, (0xdc, 0, 0))
         totalsize = bytearray(szdata['data'])[1]
         chksize = 0xf
         offset = 0
@@ -1459,8 +1486,8 @@ class Command(object):
         while offset < totalsize:
             if (offset + chksize) > totalsize:
                 chksize = totalsize - offset
-            chk = await self.raw_command(
-                netfn=0x2c, command=command, data=(0xdc, offset, chksize))
+            chk = await self._dcmi_command(command,
+                                           (0xdc, offset, chksize))
             retstr += chk['data'][2:]
             offset += chksize
         if not isinstance(retstr, str):
@@ -1477,7 +1504,7 @@ class Command(object):
             # set offset, otherwise the last setting will override
             # the previous setting
             offset += len(chunk)
-            await self.raw_command(netfn=0x2c, command=command, data=cmddata)
+            await self._dcmi_command(command, cmddata)
 
     async def set_channel_access(self, channel=None,
                            access_update_mode='non_volatile',

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -817,6 +817,25 @@ class Command(object):
         await self.oem_init()
         return await self._oem.get_sensor_reading(sensorname)
 
+    async def _fetch_lancfg_data(self, channel, param, selector=0):
+        """Internal helper for fetching a lan cfg parameter's raw data
+
+        Answers None if the bmc does not have the parameter.  Such a bmc says
+        so in the completion code and sends no data at all, so the code has to
+        be read before the payload is, and oldraw_command reports the code
+        rather than raising on it, which is why this cannot be done by
+        catching something.
+        """
+        fetchcmd = bytearray((channel, param, selector, 0))
+        fetched = await self.oldraw_command(0xc, 2, data=fetchcmd)
+        if fetched['code'] in (0x80, 0xc9):
+            # parameter not supported, and parameter out of range
+            return None
+        if fetched['code']:
+            raise exc.IpmiException(util.get_ipmi_error(fetched),
+                                    fetched['code'])
+        return bytearray(fetched['data'])
+
     async def _fetch_lancfg_param(self, channel, param, prefixlen=False):
         """Internal helper for fetching lan cfg parameters
 
@@ -824,20 +843,8 @@ class Command(object):
         string with ipv4.  If 6 bytes, colon delimited hex (mac address).  If
         one byte, return the int value
         """
-        fetchcmd = bytearray((channel, param, 0, 0))
-        fetched = await self.oldraw_command(0xc, 2, data=fetchcmd)
-        # A bmc without the parameter says so in the completion code and sends
-        # no data at all, so the code has to be read before the payload is.
-        # oldraw_command reports the code rather than raising on it, which is
-        # why this cannot be done by catching something.
-        if fetched['code'] in (0x80, 0xc9):
-            # parameter not supported, and parameter out of range
-            return None
-        if fetched['code']:
-            raise exc.IpmiException(util.get_ipmi_error(fetched),
-                                    fetched['code'])
-        fetchdata = fetched['data']
-        if not fetchdata or bytearray(fetchdata)[0] != 17:
+        fetchdata = await self._fetch_lancfg_data(channel, param)
+        if not fetchdata or fetchdata[0] != 17:
             return None
         if param == 0x14:
             vlaninfo = struct.unpack('<H', fetchdata[1:])[0]
@@ -1179,12 +1186,14 @@ class Command(object):
         """
         if channel is None:
             channel = await self.get_network_channel()
-        rqdata = (channel, 0x11, 0, 0)
-        rsp = await self.raw_command(netfn=0xc, command=2, data=rqdata)
+        rspdata = await self._fetch_lancfg_data(channel, 0x11)
+        if rspdata is None:
+            raise exc.UnsupportedFunctionality(
+                'This platform does not support alert destinations')
         await self.oem_init()
         if hasattr(self._oem, 'get_alert_destination_count'):
-            return await self._oem.get_alert_destination_count(ord(rsp['data'][1]))
-        return bytearray(rsp['data'])[1]
+            return await self._oem.get_alert_destination_count(rspdata[1])
+        return rspdata[1]
 
     async def get_alert_destination(self, destination=0, channel=None):
         """Get alert destination
@@ -1210,23 +1219,27 @@ class Command(object):
         destinfo = {}
         if channel is None:
             channel = await self.get_network_channel()
-        rqdata = (channel, 18, destination, 0)
-        rsp = await self.raw_command(netfn=0xc, command=2, data=rqdata)
-        dtype, acktimeout, retries = struct.unpack('BBB', rsp['data'][2:])
+        rspdata = await self._fetch_lancfg_data(channel, 18, destination)
+        if rspdata is None:
+            raise exc.UnsupportedFunctionality(
+                'This platform does not support alert destinations')
+        dtype, acktimeout, retries = struct.unpack('BBB', rspdata[2:])
         destinfo['acknowledge_required'] = dtype & 0b10000000 == 0b10000000
         # Ignore destination type for now...
         if destinfo['acknowledge_required']:
             destinfo['acknowledge_timeout'] = acktimeout
         destinfo['retries'] = retries
-        rqdata = (channel, 19, destination, 0)
-        rsp = await self.raw_command(netfn=0xc, command=2, data=rqdata)
-        if bytearray(rsp['data'])[2] & 0b11110000 == 0:
+        rspdata = await self._fetch_lancfg_data(channel, 19, destination)
+        if rspdata is None:
+            raise exc.UnsupportedFunctionality(
+                'This platform does not report alert destination addresses')
+        if rspdata[2] & 0b11110000 == 0:
             destinfo['address_format'] = 'ipv4'
-            destinfo['address'] = socket.inet_ntoa(rsp['data'][4:8])
-        elif bytearray(rsp['data'])[2] & 0b11110000 == 0b10000:
+            destinfo['address'] = socket.inet_ntoa(bytes(rspdata[4:8]))
+        elif rspdata[2] & 0b11110000 == 0b10000:
             destinfo['address_format'] = 'ipv6'
             destinfo['address'] = socket.inet_ntop(socket.AF_INET6,
-                                                   rsp['data'][3:])
+                                                   bytes(rspdata[3:]))
         return destinfo
 
     async def clear_alert_destination(self, destination=0, channel=None):

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -824,20 +824,17 @@ class Command(object):
     async def _fetch_lancfg_data(self, channel, param, selector=0):
         """Internal helper for fetching a lan cfg parameter's raw data
 
-        Answers None if the bmc does not have the parameter.  Such a bmc says
-        so in the completion code and sends no data at all, so the code has to
-        be read before the payload is, and oldraw_command reports the code
-        rather than raising on it, which is why this cannot be done by
-        catching something.
+        Answers None if the bmc does not have the parameter, which such a bmc
+        reports in the completion code, sending no data at all.
         """
         fetchcmd = bytearray((channel, param, selector, 0))
-        fetched = await self.oldraw_command(0xc, 2, data=fetchcmd)
-        if fetched['code'] in (0x80, 0xc9):
+        try:
+            fetched = await self.raw_command(0xc, 2, data=fetchcmd)
+        except exc.IpmiException as ie:
             # parameter not supported, and parameter out of range
-            return None
-        if fetched['code']:
-            raise exc.IpmiException(util.get_ipmi_error(fetched),
-                                    fetched['code'])
+            if ie.ipmicode in (0x80, 0xc9):
+                return None
+            raise
         return bytearray(fetched['data'])
 
     async def _fetch_lancfg_param(self, channel, param, prefixlen=False):

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -859,9 +859,10 @@ class Command(object):
         else:
             raise Exception("Unrecognized data format " + repr(fetchdata))
 
-    async def get_extended_bmc_configuration(self):
+    async def get_extended_bmc_configuration(self, hideadvanced=True):
         await self.oem_init()
-        return await self._oem.get_extended_bmc_configuration()
+        return await self._oem.get_extended_bmc_configuration(
+            hideadvanced=hideadvanced)
 
     async def get_bmc_configuration(self):
         await self.oem_init()
@@ -2037,9 +2038,15 @@ class Command(object):
         names = {}
         max_ids = await self.get_channel_max_user_count(channel)
         for uid in range(1, max_ids + 1):
-            name = await self.get_user_name(uid=uid)
-            if await self._oem.is_valid(name):
-                names[uid] = await self.get_user(uid=uid, channel=channel)
+            # A single slot that the bmc refuses to describe must not take the
+            # whole user list with it, as some bmcs leave a slot in a state
+            # where reading it returns an error rather than an empty name
+            try:
+                name = await self.get_user_name(uid=uid)
+                if await self._oem.is_valid(name):
+                    names[uid] = await self.get_user(uid=uid, channel=channel)
+            except exc.IpmiException:
+                continue
         return names
 
     async def create_user(self, uid, name, password, channel=None, callback=False,

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -1945,11 +1945,17 @@ class Command(object):
         :param return_none_on_error: return None on error
             TODO: investigate return code on error
         """
-        response = await self.raw_command(netfn=0x06, command=0x46, data=(uid,))
-        if 'error' in response:
-            if return_none_on_error:
+        try:
+            response = await self.raw_command(netfn=0x06, command=0x46,
+                                              data=(uid,))
+        except exc.IpmiException as ie:
+            # A completion code is the bmc answering about this slot, and some
+            # leave a slot in a state where that answer is an error rather than
+            # an empty name.  A timeout or a lost session is not an answer, and
+            # reading one as an empty slot would quietly shorten a user list.
+            if return_none_on_error and 0 < ie.ipmicode <= 0xff:
                 return None
-            raise Exception(response['error'])
+            raise
         name = None
         if 'data' in response:
             data = response['data']
@@ -2091,15 +2097,11 @@ class Command(object):
         names = {}
         max_ids = await self.get_channel_max_user_count(channel)
         for uid in range(1, max_ids + 1):
-            # A single slot that the bmc refuses to describe must not take the
-            # whole user list with it, as some bmcs leave a slot in a state
-            # where reading it returns an error rather than an empty name
-            try:
-                name = await self.get_user_name(uid=uid)
-                if await self._oem.is_valid(name):
-                    names[uid] = await self.get_user(uid=uid, channel=channel)
-            except exc.IpmiException:
-                continue
+            # A slot the bmc refuses to describe reads as no name at all, so it
+            # is skipped here the same way an empty one is
+            name = await self.get_user_name(uid=uid)
+            if await self._oem.is_valid(name):
+                names[uid] = await self.get_user(uid=uid, channel=channel)
         return names
 
     async def create_user(self, uid, name, password, channel=None, callback=False,

--- a/confluent_server/aiohmi/ipmi/command.py
+++ b/confluent_server/aiohmi/ipmi/command.py
@@ -2233,7 +2233,10 @@ class Command(object):
         await self.oem_init()
         mcinfo = await self.raw_command(netfn=6, command=1)
         major, minor = struct.unpack('BB', mcinfo['data'][2:4])
-        bmcver = '{0}.{1}'.format(major, hex(minor)[2:])
+        # The top bit of the major byte says the device is still initialising
+        # or taking an update, and is not part of the revision, so mask it off
+        # the way sdr.py does rather than reporting 131.11 for 3.11
+        bmcver = '{0}.{1}'.format(major & 0b1111111, hex(minor)[2:])
         async for x in self._oem.get_oem_firmware(bmcver, components, category):
             yield x
 

--- a/confluent_server/aiohmi/ipmi/oem/generic.py
+++ b/confluent_server/aiohmi/ipmi/oem/generic.py
@@ -455,7 +455,7 @@ class OEMHandler(object):
         """
         return False
 
-    async def get_extended_bmc_configuration(self):
+    async def get_extended_bmc_configuration(self, hideadvanced=True):
         """Get extended bmc configuration
 
         In the case of potentially redundant/slow

--- a/confluent_server/aiohmi/ipmi/oem/generic.py
+++ b/confluent_server/aiohmi/ipmi/oem/generic.py
@@ -391,10 +391,12 @@ class OEMHandler(object):
         return False
 
     async def detach_remote_media(self):
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Remote media is not supported on this platform')
 
     async def attach_remote_media(self, imagename, username, password):
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Remote media is not supported on this platform')
 
     async def upload_media(self, filename, progress, data):
         raise exc.UnsupportedFunctionality(
@@ -403,7 +405,8 @@ class OEMHandler(object):
     async def list_media(self):
         if False:
             yield None
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Remote media is not supported on this platform')
 
     async def set_identify(self, on, duration, blink):
         """Provide an OEM override for set_identify
@@ -411,7 +414,8 @@ class OEMHandler(object):
         Some systems may require an override for set identify.
 
         """
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Identify is not supported on this platform')
 
     async def get_health(self, summary):
         """Provide an alternative or augmented health assessment
@@ -428,16 +432,19 @@ class OEMHandler(object):
 
     async def set_hostname(self, hostname):
         """OEM specific hook to specify name information"""
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Setting the bmc hostname is not supported on this platform')
 
     async def get_hostname(self):
         """OEM specific hook to specify name information"""
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Reading the bmc hostname is not supported on this platform')
 
     async def set_user_access(self, uid, channel, callback, link_auth, ipmi_msg,
                         privilege_level):
         if privilege_level.startswith('custom.'):
-            raise exc.UnsupportedFunctionality()
+            raise exc.UnsupportedFunctionality(
+                'Custom privilege levels are not supported on this platform')
         return  # Nothing to do
 
     async def set_alert_ipv6_destination(self, ip, destination, channel):
@@ -491,21 +498,26 @@ class OEMHandler(object):
 
         Takes a key value pair and applies it against the system configuration
         """
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Setting system configuration is not supported on this platform')
 
     async def get_licenses(self):
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Licenses are not supported on this platform')
         yield None
 
     async def delete_license(self, name):
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Licenses are not supported on this platform')
 
     async def save_licenses(self, directory):
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Licenses are not supported on this platform')
         yield None
 
     async def apply_license(self, filename, progress=None, data=None):
-        raise exc.UnsupportedFunctionality()
+        raise exc.UnsupportedFunctionality(
+            'Licenses are not supported on this platform')
         yield None
 
     async def get_user_expiration(self, uid):

--- a/confluent_server/aiohmi/ipmi/oem/generic.py
+++ b/confluent_server/aiohmi/ipmi/oem/generic.py
@@ -301,6 +301,11 @@ class OEMHandler(object):
         # code to know whether it cares or not.  The main purpose of the
         # components argument is to indicate when certain performance
         # optimizations can be performed.
+        if category not in (None, 'all', 'core'):
+            # The bmc firmware is system firmware, so it is the answer to
+            # 'core' and to nothing else. Without this a request for, say,
+            # disk firmware answers with the bmc version.
+            return
         yield 'BMC Version', {'version': bmcver}
 
     async def get_oem_capping_enabled(self):

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
@@ -702,7 +702,8 @@ class OEMHandler(generic.OEMHandler):
         elif await self.has_xcc():
             await self.immhandler.set_identify(on, duration, blink)
         else:
-            raise pygexc.UnsupportedFunctionality()
+            raise pygexc.UnsupportedFunctionality(
+                'Identify is not supported on this platform')
 
     async def process_fru(self, fru, name=None):
         if fru is None:

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/handler.py
@@ -1223,10 +1223,12 @@ class OEMHandler(generic.OEMHandler):
             return {'height': self._fpc_variant & 0xf, 'slot': 0}
         return await super(OEMHandler, self).get_description()
 
-    async def get_extended_bmc_configuration(self):
+    async def get_extended_bmc_configuration(self, hideadvanced=True):
         if await self.has_xcc():
-            return await self.immhandler.get_extended_bmc_configuration()
-        return await super(OEMHandler, self).get_extended_bmc_configuration()
+            return await self.immhandler.get_extended_bmc_configuration(
+                hideadvanced=hideadvanced)
+        return await super(OEMHandler, self).get_extended_bmc_configuration(
+            hideadvanced=hideadvanced)
 
     async def get_bmc_configuration(self):
         if await self.has_xcc():

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
@@ -1013,7 +1013,8 @@ class XCCClient(IMMClient):
                 {'IndicatorLED': 'Blinking'},
                 method='PATCH')
             raise pygexc.BypassGenericBehavior()
-        raise pygexc.UnsupportedFunctionality()
+        raise pygexc.UnsupportedFunctionality(
+            'Identify is not supported on this platform')
 
     async def get_description(self):
         wc = await self.wc()

--- a/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
@@ -1026,7 +1026,7 @@ class XCCClient(IMMClient):
                 return {}
         return {'height': int(dsc['u-height']), 'slot': int(dsc['slot'])}
 
-    async def get_extended_bmc_configuration(self):
+    async def get_extended_bmc_configuration(self, hideadvanced=True):
         immsettings = await self.get_system_configuration(fetchimm=True)
         for setting in list(immsettings):
             if not setting.startswith('IMM.'):

--- a/confluent_server/aiohmi/ipmi/sdr.py
+++ b/confluent_server/aiohmi/ipmi/sdr.py
@@ -687,11 +687,15 @@ class SDR(object):
                 # The device has sensor device support, so in theory we should
                 # be able to proceed
                 # However at the moment, we haven't done so
-                raise NotImplementedError
-            return
+                raise exc.UnsupportedFunctionality(
+                    'This bmc keeps its sensor data records on the sensor '
+                    'device rather than in a repository, which is not '
+                    'supported')
             # We have Device SDR, without SDR Repository device, but
             # also without sensor device support, no idea how to
             # continue
+            raise exc.UnsupportedFunctionality(
+                'This bmc offers no way to read its sensor data records')
         await self.get_sdr()
 
     async def get_sdr_reservation(self):
@@ -706,7 +710,9 @@ class SDR(object):
         if (repinfo['data'][0] != 0x51):
             # we only understand SDR version 51h, the only version defined
             # at time of this writing
-            raise NotImplementedError
+            raise exc.UnsupportedFunctionality(
+                'This bmc reports sensor data record version {0:#x}, and only '
+                '0x51 is understood'.format(repinfo['data'][0]))
         # NOTE(jbjohnso): we actually don't need to care about 'numrecords'
         # since FFFF marks the end explicitly
         # numrecords = (rsp['data'][2] << 8) + rsp['data'][1]

--- a/confluent_server/aiohmi/ipmi/sdr.py
+++ b/confluent_server/aiohmi/ipmi/sdr.py
@@ -620,12 +620,12 @@ class SDREntry(object):
             return ""
         if ipmitype == 0:  # Unicode per 43.15 in ipmi 2.0 spec
             # the spec is not specific about encoding, assuming utf8
-            return struct.pack("%dB" % len(data), *data).decode("utf-8")
+            ret = struct.pack("%dB" % len(data), *data).decode("utf-8")
         elif ipmitype == 1:  # BCD '+'
             tmpl = "%02X" * len(data)
             tstr = tmpl % tuple(data)
             tstr = tstr.replace("A", " ").replace("B", "-").replace("C", ".")
-            return tstr.replace("D", ":").replace("E", ",").replace("F", "_")
+            ret = tstr.replace("D", ":").replace("E", ",").replace("F", "_")
         elif ipmitype == 2:  # 6 bit ascii, start at 0x20
             # the ordering is very peculiar and is best understood from
             # IPMI SPEC "6-bit packed ascii example
@@ -637,12 +637,14 @@ class SDREntry(object):
                 tstr += chr((data[2] >> 2) + 0x20)
             if not isinstance(tstr, str):
                 tstr = tstr.decode('utf-8')
-            return tstr
-        elif ipmitype == 3:  # ACSII+LATIN1
+            ret = tstr
+        else:  # ipmitype == 3, ASCII+LATIN1
             ret = struct.pack("%dB" % len(data), *data)
             if not isinstance(ret, str):
                 ret = ret.decode('utf-8')
-            return ret
+        # A fixed width field is padded out with nulls.  They are not part of
+        # the name, and would stop a caller ever matching on it.
+        return ret.rstrip('\x00')
 
 
 class SDR(object):
@@ -684,13 +686,9 @@ class SDR(object):
             # device, so we are meant to use an alternative mechanism to get
             # SDR data
             if rsp['data'][5] & 1:
-                # The device has sensor device support, so in theory we should
-                # be able to proceed
-                # However at the moment, we haven't done so
-                raise exc.UnsupportedFunctionality(
-                    'This bmc keeps its sensor data records on the sensor '
-                    'device rather than in a repository, which is not '
-                    'supported')
+                # The device has sensor device support, so the records are
+                # read from the sensor device a lun at a time instead
+                return await self.get_device_sdr()
             # We have Device SDR, without SDR Repository device, but
             # also without sensor device support, no idea how to
             # continue
@@ -703,6 +701,151 @@ class SDR(object):
         if rsp['code'] != 0:
             raise exc.IpmiException(rsp['error'])
         return rsp['data'][0] + (rsp['data'][1] << 8)
+
+    async def get_device_sdr_reservation(self):
+        rsp = await self.ipmicmd.raw_command(netfn=4, command=0x22)
+        if rsp['code'] != 0:
+            raise exc.IpmiException(rsp['error'])
+        return rsp['data'][0] + (rsp['data'][1] << 8)
+
+    async def get_device_sdr_info(self):
+        """Ask the sensor device about its records
+
+        Answers the luns that have sensors and a change indicator to cache on,
+        which is only present when the device says its sensors are populated
+        dynamically.
+        """
+        rsp = await self.ipmicmd.raw_command(netfn=4, command=0x20, data=(1,))
+        if rsp['code'] != 0:
+            raise exc.IpmiException(rsp['error'])
+        data = bytearray(rsp['data'])
+        luns = [lun for lun in range(4) if data[1] & (1 << lun)]
+        if not luns:
+            # A device that names no lun still has to answer for lun 0, and
+            # some do not set the bit for it
+            luns = [0]
+        modtime = 0
+        if data[1] & 0b10000000 and len(data) >= 6:
+            modtime = struct.unpack('<I', bytes(data[2:6]))[0]
+        return luns, modtime
+
+    async def get_device_sdr(self):
+        """Read the sensor data records from the sensor device
+
+        For a bmc with no sdr repository.  The records themselves are the same,
+        so only the fetching differs: a different command, a reservation of its
+        own, and the records are held per lun rather than in one place.
+        """
+        luns, modtime = await self.get_device_sdr_info()
+        self.broken_sensor_ids = {}
+        cachekey = (self.fw_major, self.fw_minor, self.mfg_id, self.prod_id,
+                    self.device_id, 'device', modtime)
+        cachefilename = None
+        if modtime:
+            # Without a change indicator there is nothing to notice a change
+            # by, so such a device is read afresh every time
+            try:
+                csdrs = shared_sdrs[cachekey]
+                self.sensors = csdrs['sensors']
+                self.fru = csdrs['fru']
+                return
+            except KeyError:
+                pass
+            if self.cachedir:
+                cachefilename = os.path.join(
+                    self.cachedir,
+                    'sdrcache-2.device.{0}.{1}.{2}.{3}.{4}.{5}'.format(
+                        self.mfg_id, self.prod_id, self.device_id,
+                        self.fw_major, self.fw_minor, modtime))
+        if cachefilename and os.path.isfile(cachefilename):
+            with open(cachefilename, 'rb') as cfile:
+                csdrlen = cfile.read(2)
+                while csdrlen:
+                    csdrlen = struct.unpack('!H', csdrlen)[0]
+                    await self.add_sdr(cfile.read(csdrlen))
+                    csdrlen = cfile.read(2)
+        else:
+            sdrraw = [] if cachefilename else None
+            for lun in luns:
+                await self._read_device_sdr_lun(lun, sdrraw)
+            if cachefilename:
+                self._write_sdr_cache(cachefilename, sdrraw)
+        for sid in self.broken_sensor_ids:
+            try:
+                del self.sensors[sid]
+            except KeyError:
+                pass
+        if modtime:
+            shared_sdrs[cachekey] = {
+                'sensors': self.sensors,
+                'fru': self.fru,
+            }
+
+    def _write_sdr_cache(self, cachefilename, sdrraw):
+        suffix = ''.join(
+            random.choice(string.ascii_lowercase) for _ in range(12))
+        with open(cachefilename + '.' + suffix, 'wb') as cfile:
+            for csdr in sdrraw:
+                cfile.write(struct.pack('!H', len(csdr)))
+                cfile.write(csdr)
+        os.rename(cachefilename + '.' + suffix, cachefilename)
+
+    async def _read_device_sdr_lun(self, lun, sdrraw=None):
+        recid = 0
+        rsvid = 0
+        offset = 0
+        size = 0xff
+        chunksize = 128
+        while recid != 0xffff:  # per 35.3 Get Device SDR, 0xffff marks the end
+            newrecid = 0
+            currlen = 0
+            sdrdata = bytearray()
+            while True:  # loop until SDR fetched wholly
+                if size != 0xff and rsvid == 0:
+                    rsvid = await self.get_device_sdr_reservation()
+                rqdata = [rsvid & 0xff, rsvid >> 8,
+                          recid & 0xff, recid >> 8,
+                          offset, size]
+                sdrrec = await self.ipmicmd.raw_command(
+                    netfn=4, command=0x21, data=rqdata, rslun=lun)
+                if sdrrec['code'] == 0xca:
+                    if size == 0xff:  # get just 5 to get header to know length
+                        size = 5
+                    elif size > 5:
+                        size //= 2
+                        # push things over such that it's less
+                        # likely to be just 1 short of a read
+                        # and incur a whole new request
+                        size += 2
+                        chunksize = size
+                    continue
+                if sdrrec['code'] == 0xc5:  # need a new reservation id
+                    rsvid = 0
+                    continue
+                if sdrrec['code'] != 0:
+                    raise exc.IpmiException(sdrrec['error'])
+                if newrecid == 0:
+                    newrecid = (sdrrec['data'][1] << 8) + sdrrec['data'][0]
+                if currlen == 0:
+                    currlen = sdrrec['data'][6] + 5  # compensate for header
+                sdrdata.extend(sdrrec['data'][2:])
+                offset += size
+                if offset >= currlen:
+                    break
+                if size == 5 and offset == 5:
+                    # bump up size after header retrieval
+                    size = chunksize
+                if (offset + size) > currlen:
+                    size = currlen - offset
+            await self.add_sdr(sdrdata)
+            if sdrraw is not None:
+                sdrraw.append(bytes(sdrdata))
+            offset = 0
+            if size != 0xff:
+                size = 5
+            if newrecid == recid:
+                raise exc.BmcErrorException("Incorrect SDR record id from BMC")
+            recid = newrecid
 
     async def get_sdr(self):
         repinfo = await self.ipmicmd.raw_command(netfn=0x0a, command=0x20)

--- a/confluent_server/aiohmi/ipmi/sdr.py
+++ b/confluent_server/aiohmi/ipmi/sdr.py
@@ -825,7 +825,9 @@ class SDR(object):
                 rqdata = [rsvid & 0xff, rsvid >> 8,
                           recid & 0xff, recid >> 8,
                           offset, size]
-                sdrrec = await self.ipmicmd.raw_command(
+                # Not raw_command: it raises on the completion codes below,
+                # which are the ones this loop exists to act on
+                sdrrec = await self.ipmicmd.oldraw_command(
                     netfn=4, command=0x21, data=rqdata, rslun=lun)
                 if sdrrec['code'] == 0xca:
                     if size == 0xff:  # get just 5 to get header to know length

--- a/confluent_server/aiohmi/ipmi/sdr.py
+++ b/confluent_server/aiohmi/ipmi/sdr.py
@@ -721,8 +721,11 @@ class SDR(object):
             raise exc.IpmiException(rsp['error'])
         return rsp['data'][0] + (rsp['data'][1] << 8)
 
-    async def get_device_sdr_reservation(self):
-        rsp = await self.ipmicmd.raw_command(netfn=4, command=0x22)
+    async def get_device_sdr_reservation(self, lun=0):
+        # To the lun whose records are about to be read: a device holds its
+        # sensor records per lun, and a bmc that scopes the reservation the
+        # same way answers 0xc5 to a token taken against a different one
+        rsp = await self.ipmicmd.raw_command(netfn=4, command=0x22, rslun=lun)
         if rsp['code'] != 0:
             raise exc.IpmiException(rsp['error'])
         return rsp['data'][0] + (rsp['data'][1] << 8)
@@ -818,10 +821,11 @@ class SDR(object):
         while recid != 0xffff:  # per 35.3 Get Device SDR, 0xffff marks the end
             newrecid = 0
             currlen = 0
+            rsvattempts = 0
             sdrdata = bytearray()
             while True:  # loop until SDR fetched wholly
                 if size != 0xff and rsvid == 0:
-                    rsvid = await self.get_device_sdr_reservation()
+                    rsvid = await self.get_device_sdr_reservation(lun)
                 rqdata = [rsvid & 0xff, rsvid >> 8,
                           recid & 0xff, recid >> 8,
                           offset, size]
@@ -845,8 +849,15 @@ class SDR(object):
                         continue
                 if sdrrec['code'] == 0xc5:  # need a new reservation id
                     # Take one here rather than leaving it to the top of the
-                    # loop, which only reserves for a partial read
-                    rsvid = await self.get_device_sdr_reservation()
+                    # loop, which only reserves for a partial read.  Bounded,
+                    # because a bmc that will not honour a token we can take
+                    # would otherwise answer 0xc5 to every retry for ever.
+                    if rsvattempts >= 3:
+                        raise exc.IpmiException(
+                            'The bmc kept rejecting the sensor record '
+                            'reservation for lun {0}'.format(lun))
+                    rsvattempts += 1
+                    rsvid = await self.get_device_sdr_reservation(lun)
                     continue
                 if sdrrec['code'] != 0:
                     raise exc.IpmiException(sdrrec['error'])

--- a/confluent_server/aiohmi/ipmi/sdr.py
+++ b/confluent_server/aiohmi/ipmi/sdr.py
@@ -832,16 +832,21 @@ class SDR(object):
                 if sdrrec['code'] == 0xca:
                     if size == 0xff:  # get just 5 to get header to know length
                         size = 5
-                    elif size > 5:
-                        size //= 2
-                        # push things over such that it's less
-                        # likely to be just 1 short of a read
-                        # and incur a whole new request
-                        size += 2
-                        chunksize = size
-                    continue
+                        continue
+                    # push things over such that it's less
+                    # likely to be just 1 short of a read
+                    # and incur a whole new request
+                    smaller = size // 2 + 2
+                    # Asking again unchanged would never end, and a header read
+                    # under 5 bytes could not carry the record length, so fall
+                    # through to the raise below rather than retry either
+                    if smaller < size and (currlen != 0 or smaller >= 5):
+                        size = chunksize = smaller
+                        continue
                 if sdrrec['code'] == 0xc5:  # need a new reservation id
-                    rsvid = 0
+                    # Take one here rather than leaving it to the top of the
+                    # loop, which only reserves for a partial read
+                    rsvid = await self.get_device_sdr_reservation()
                     continue
                 if sdrrec['code'] != 0:
                     raise exc.IpmiException(sdrrec['error'])

--- a/confluent_server/aiohmi/ipmi/sdr.py
+++ b/confluent_server/aiohmi/ipmi/sdr.py
@@ -635,6 +635,13 @@ class SDREntry(object):
                 tstr += chr(((data[1] & 0b1111) << 2) + (data[0] >> 6) + 0x20)
                 tstr += chr(((data[2] & 0b11) << 4) + (data[1] >> 4) + 0x20)
                 tstr += chr((data[2] >> 2) + 0x20)
+                data = data[3:]
+            # A trailing byte or two is a short group rather than padding, and
+            # still carries a character each, so dropping it truncates the name
+            if len(data) >= 1:
+                tstr += chr((data[0] & 0b111111) + 0x20)
+            if len(data) == 2:
+                tstr += chr(((data[1] & 0b1111) << 2) + (data[0] >> 6) + 0x20)
             if not isinstance(tstr, str):
                 tstr = tstr.decode('utf-8')
             ret = tstr

--- a/confluent_server/aiohmi/ipmi/sdr.py
+++ b/confluent_server/aiohmi/ipmi/sdr.py
@@ -429,8 +429,19 @@ class SDREntry(object):
                     self.sensor_type = 'Energy'
         self.baseunit = unit_types[entry[16]]
         self.modunit = unit_types[entry[17]]
-        self.unit_suffix = self.percent + self.baseunit + self.unit_mod + \
-            self.modunit
+        # A sensor has a number for the unit fields to describe only if the
+        # record says how to read one, everything else is discrete and reports
+        # states alone (table 42-1).  This is the same question the reading
+        # path asks to decide whether to decode a number, asked once here so
+        # that the unit and the value cannot disagree about it.
+        self.has_numeric_reading = (
+            self.numeric_format in (1, 2)
+            or (self.numeric_format == 0
+                and (self.has_thresholds or self.reading_type == 1)))
+        self.unit_suffix = ''
+        if self.has_numeric_reading:
+            self.unit_suffix = self.percent + self.baseunit + self.unit_mod + \
+                self.modunit
 
     def full_decode(self, entry):
         # offsets are table from spec, minus 6
@@ -485,12 +496,13 @@ class SDREntry(object):
         if reading[1] & 0b100000 or not reading[1] & 0b1000000:
             output['unavailable'] = 1
             return SensorReading(output, self.unit_suffix)
-        if self.numeric_format == 2:
-            numeric = twos_complement(reading[0], 8)
-        elif self.numeric_format == 1:
-            numeric = ones_complement(reading[0], 8)
-        elif self.numeric_format == 0 and (self.has_thresholds or self.reading_type == 1):
-            numeric = reading[0]
+        if self.has_numeric_reading:
+            if self.numeric_format == 2:
+                numeric = twos_complement(reading[0], 8)
+            elif self.numeric_format == 1:
+                numeric = ones_complement(reading[0], 8)
+            else:
+                numeric = reading[0]
         discrete = True
         if numeric is not None:
             lowerbound = numeric - (0.5 + (self.tolerance / 2.0))

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -606,6 +606,12 @@ class Command(object):
         if payload is None and method is None:
             self._urlcache[url] = {'contents': res[0],
                                    'vintage': os.times()[4]}
+        elif method != 'GET':
+            # A write may have changed anything, including documents other than
+            # the one written (an action url is not the resource it acts on), so
+            # do not let a cached read from before the write be handed out as
+            # the current state
+            self._urlcache.clear()
         return res[0]
 
     async def get_bootdev(self):

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1329,8 +1329,11 @@ class Command(object):
         fwurls = [x['@odata.id'] for x in fwlist.get('Members', [])]
         wantcategory = category if category not in (None, 'all') else None
         entries = []
-        async for res in self._do_bulk_requests(fwurls):
-            entries.append((self._fwcategory(res[0]), self._extract_fwinfo(res)))
+        results = [res async for res in self._do_bulk_requests(fwurls)]
+        labels = self._firmware_labels(results)
+        for res in results:
+            entries.append((self._fwcategory(res[0]),
+                            self._extract_fwinfo(res, labels)))
         categorised = any(x[0] for x in entries)
         for fwcategory, res in entries:
             if res[0] is None:
@@ -1346,10 +1349,32 @@ class Command(object):
                     continue
             yield res
 
-    def _extract_fwinfo(self, inf):
+    def _firmware_labels(self, results):
+        """Pick something to call each firmware entry.
+
+        A platform is free to give every entry the same Name, which then tells
+        them apart from nothing, so where that happens look for a description
+        that does, and fall back to the id.
+        """
+        names = [x[0].get('Name', 'Unknown') for x in results]
+        descs = [x[0].get('Description', '') for x in results]
+        labels = {}
+        for idx, (fwi, url) in enumerate(results):
+            label = names[idx]
+            if names.count(label) > 1:
+                if descs[idx] and descs.count(descs[idx]) == 1:
+                    label = descs[idx]
+                else:
+                    label = fwi.get('Id', label)
+            labels[url] = label
+        return labels
+
+    def _extract_fwinfo(self, inf, labels=None):
         currinf = self._oem._extract_fwinfo(inf)
         fwi, url = inf
         fwname = fwi.get('Name', 'Unknown')
+        if labels:
+            fwname = labels.get(url, fwname)
         if fwname in self._fwnamemap:
             fwname = fwi.get('Id', fwname)
         if fwname in self._fwnamemap:

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1268,10 +1268,23 @@ class Command(object):
             return
         fwlist = await self._do_web_request(await self.get_fwinventory())
         fwurls = [x['@odata.id'] for x in fwlist.get('Members', [])]
+        wantcategory = category if category not in (None, 'all') else None
+        entries = []
         async for res in self._do_bulk_requests(fwurls):
-            res = self._extract_fwinfo(res)
+            entries.append((self._fwcategory(res[0]), self._extract_fwinfo(res)))
+        categorised = any(x[0] for x in entries)
+        for fwcategory, res in entries:
             if res[0] is None:
                 continue
+            if wantcategory:
+                if categorised:
+                    if fwcategory != wantcategory:
+                        continue
+                elif wantcategory != 'core':
+                    # This platform does not say what any of its firmware
+                    # belongs to, and an uncategorised inventory on a bmc is
+                    # system firmware, so it can only answer for 'core'
+                    continue
             yield res
 
     def _extract_fwinfo(self, inf):
@@ -1577,32 +1590,48 @@ class Command(object):
                 if 'Authorization' in self.wc.stdheaders:
                     del self.wc.stdheaders['Authorization']            
             return
+        attached = False
         for vmurl in vmurls:
             vminfo = await self._do_web_request(vmurl, cache=False)
-            if vminfo.get('ConnectedVia', None) != 'NotConnected':
+            # ConnectedVia describes how the device is wired to the host rather
+            # than whether anything is in it, and some implementations report a
+            # permanent value there, so judge free by whether an image is loaded
+            if vminfo.get('Image', None) or vminfo.get('Inserted', False):
                 continue
             inserturl = vminfo.get(
                 'Actions', {}).get(
                     '#VirtualMedia.InsertMedia', {}).get('target', None)
             if inserturl:
-                await self._do_web_request(inserturl, {'Image': url})
-            else:
+                try:
+                    await self._do_web_request(inserturl, {'Image': url})
+                    attached = True
+                except (exc.RedfishError, exc.PyghmiException):
+                    # Some implementations advertise the insert action without
+                    # serving it, so fall back to setting the properties
+                    inserturl = None
+            if not inserturl:
                 try:
                     await self._do_web_request(vmurl,
                                                {'Image': url, 'Inserted': True},
-                                               'PATCH')
+                                               'PATCH', etag='*')
                 except exc.RedfishError as re:
                     if re.msgid.endswith(u'PropertyUnknown'):
-                        await self._do_web_request(vmurl, {'Image': url}, 'PATCH')
+                        await self._do_web_request(vmurl, {'Image': url}, 'PATCH',
+                                                   etag='*')
                     else:
                         raise
+                attached = True
             break
         if suspendedxauth:
                 self.wc.stdheaders['X-Auth-Token'] = self.xauthtoken
                 if 'Authorization' in self.wc.stdheaders:
-                    del self.wc.stdheaders['Authorization']    
+                    del self.wc.stdheaders['Authorization']
+        if not attached:
+            raise exc.UnsupportedFunctionality(
+                'No virtual media device on this platform was able to accept '
+                'the image')
         async for res in oem.list_media(self, cache=False):
-            pass          
+            pass
 
     async def detach_remote_media(self):
         oem = await self.oem()

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -866,7 +866,16 @@ class Command(object):
                 if len(targurl.get('Members', [])) == 1:
                     targurl = targurl['Members'][0]['@odata.id']
         if not targurl:
-            raise Exception("Unable to identify system url")        
+            raise Exception("Unable to identify system url")
+        targinfo = await self._do_web_request(targurl)
+        if ('IndicatorLED' not in targinfo
+                and 'LocationIndicatorActive' in targinfo):
+            # IndicatorLED is deprecated in favour of a boolean, which has no
+            # way to ask for blinking, so blinking becomes simply lit
+            await self._do_web_request(
+                targurl, {'LocationIndicatorActive': bool(blink or on)},
+                method='PATCH', etag='*')
+            return
         await self._do_web_request(
             targurl,
             {'IndicatorLED': 'Blinking' if blink else 'Lit' if on else 'Off'},
@@ -878,9 +887,27 @@ class Command(object):
         'Off': 'off',
     }
 
+    def _indicator_state(self, info):
+        """Read a location indicator, by either the old or the current property.
+
+        Returns None when the resource does not describe one.
+        """
+        ledstate = info.get('IndicatorLED', None)
+        if ledstate is not None:
+            if ledstate not in self._idstatemap:
+                raise exc.PyghmiException(
+                    'Unrecognized indicator LED state "{0}"'.format(ledstate))
+            return self._idstatemap[ledstate]
+        # IndicatorLED is deprecated in favour of a boolean, which cannot
+        # express blinking
+        active = info.get('LocationIndicatorActive', None)
+        if active is None:
+            return None
+        return 'on' if active else 'off'
+
     async def get_identify(self):
         sysinfo = await self.sysinfo()
-        ledstate = sysinfo.get('IndicatorLED', None)
+        idstate = self._indicator_state(sysinfo)
         # The physical indicator belongs to the chassis, and some
         # implementations do not refresh the system copy of it when it
         # changes, so prefer a chassis that describes this system alone.
@@ -888,16 +915,14 @@ class Command(object):
             chassisinfo = await self._do_web_request(chassis['@odata.id'])
             if len(chassisinfo.get('Links', {}).get('ComputerSystems', [])) > 1:
                 continue
-            if chassisinfo.get('IndicatorLED', None) in self._idstatemap:
-                ledstate = chassisinfo['IndicatorLED']
+            chassisstate = self._indicator_state(chassisinfo)
+            if chassisstate is not None:
+                idstate = chassisstate
                 break
-        if ledstate is None:
+        if idstate is None:
             raise exc.UnsupportedFunctionality(
                 'Indicator LED state is not reported by this platform')
-        if ledstate not in self._idstatemap:
-            raise exc.PyghmiException(
-                'Unrecognized indicator LED state "{0}"'.format(ledstate))
-        return {'identifystate': self._idstatemap[ledstate]}
+        return {'identifystate': idstate}
 
     async def get_health(self, verbose=True):
         oem = await self.oem()
@@ -1209,9 +1234,9 @@ class Command(object):
         return bool(gconsole.get('ServiceEnabled', False))
 
     _ledstatusmap = {
-        'Lit': 'On',
-        'Blinking': 'Blink',
-        'Off': 'Off',
+        'on': 'On',
+        'blink': 'Blink',
+        'off': 'Off',
     }
 
     async def get_leds(self):
@@ -1221,17 +1246,15 @@ class Command(object):
         platform without an oem specific view of its leds can report.
         """
         sysinfo = await self.sysinfo()
-        seen = False
+        state = None
         for chassis in sysinfo.get('Links', {}).get('Chassis', []):
             chassisinfo = await self._do_web_request(chassis['@odata.id'])
-            state = chassisinfo.get('IndicatorLED', None)
-            if state is None:
-                continue
-            seen = True
-            yield ('identify', {'status': self._ledstatusmap.get(state, state)})
-            break
-        if not seen and sysinfo.get('IndicatorLED', None) is not None:
-            state = sysinfo['IndicatorLED']
+            state = self._indicator_state(chassisinfo)
+            if state is not None:
+                break
+        if state is None:
+            state = self._indicator_state(sysinfo)
+        if state is not None:
             yield ('identify', {'status': self._ledstatusmap.get(state, state)})
 
     # A firmware inventory entry says what it belongs to with RelatedItem, so

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1349,7 +1349,12 @@ class Command(object):
         fwurls = [x['@odata.id'] for x in fwlist.get('Members', [])]
         wantcategory = category if category not in (None, 'all') else None
         entries = []
-        results = [res async for res in self._do_bulk_requests(fwurls)]
+        # Every entry has to be in hand before any can be named, since a name is
+        # only ambiguous in relation to the others.  An entry that answered with
+        # nothing has nothing to report and must not take the naming of the rest
+        # with it.
+        results = [res async for res in self._do_bulk_requests(fwurls)
+                   if res[0]]
         labels = self._firmware_labels(results)
         for res in results:
             entries.append((self._fwcategory(res[0]),

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -321,17 +321,18 @@ class Command(object):
                         }
         return names
 
-    async def _account_url_info_by_id(self, uid):
+    async def _account_url_info_by_id(self, uid, cache=True):
         srvurl = await self._accountserviceurl()
         oem = await self.oem()
         if srvurl:
-            srvinfo = await self._do_web_request(srvurl)
+            srvinfo = await self._do_web_request(srvurl, cache=cache)
             srvurl = srvinfo.get('Accounts', {}).get('@odata.id', None)
             if srvurl:
-                srvinfo = await self._do_web_request(srvurl)
+                srvinfo = await self._do_web_request(srvurl, cache=cache)
                 accounts = srvinfo.get('Members', [])
                 for account in accounts:
-                    accinfo = await self._do_web_request(account['@odata.id'])
+                    accinfo = await self._do_web_request(account['@odata.id'],
+                                                         cache=cache)
                     currid = accinfo.get('Id', None)
                     if str(currid) == str(uid):
                         accinfo['expiration'] = await oem.get_user_expiration(

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -697,8 +697,13 @@ class Command(object):
                 # than passing the bmc's complaint on as an unexpected error.
                 try:
                     await self._do_web_request(biosurl)
-                except exc.RedfishError as re:
-                    if 'ResourceNotFound' not in str(re.msgid):
+                except exc.PyghmiException:
+                    # A link that is not served need not answer with a redfish
+                    # error, and the exception cannot say what the status was,
+                    # so ask.  Anything else is a fault, not an answer.
+                    _, status = await self.wc.grab_json_response_with_status(
+                        biosurl)
+                    if status not in (404, 405, 501):
                         raise
                     biosurl = ''
             # '' is remembered as 'asked, and there is none'

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1360,19 +1360,15 @@ class Command(object):
         for res in results:
             entries.append((self._fwcategory(res[0]),
                             self._extract_fwinfo(res, labels)))
-        categorised = any(x[0] for x in entries)
         for fwcategory, res in entries:
             if res[0] is None:
                 continue
-            if wantcategory:
-                if categorised:
-                    if fwcategory != wantcategory:
-                        continue
-                elif wantcategory != 'core':
-                    # This platform does not say what any of its firmware
-                    # belongs to, and an uncategorised inventory on a bmc is
-                    # system firmware, so it can only answer for 'core'
-                    continue
+            # An entry that says nothing about what it belongs to is system
+            # firmware, which is what firmware on a bmc is unless it points at
+            # something else.  This holds for a whole inventory that names no
+            # relations and for the odd entry among ones that do.
+            if wantcategory and (fwcategory or 'core') != wantcategory:
+                continue
             yield res
 
     def _firmware_labels(self, results):

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -688,11 +688,22 @@ class Command(object):
         return await oem.set_bootdev(bootdev, persist, uefiboot, self)
 
     async def get_biosurl(self):
-        if not self._varbiosurl:
-            sysinfo = await self.sysinfo()
-            self._varbiosurl = sysinfo.get('Bios', {}).get('@odata.id',
-                                                          None)
         if self._varbiosurl is None:
+            sysinfo = await self.sysinfo()
+            biosurl = sysinfo.get('Bios', {}).get('@odata.id', '')
+            if biosurl:
+                # A link may be advertised and not served.  To a caller that is
+                # the same as not having one, so answer the same way rather
+                # than passing the bmc's complaint on as an unexpected error.
+                try:
+                    await self._do_web_request(biosurl)
+                except exc.RedfishError as re:
+                    if 'ResourceNotFound' not in str(re.msgid):
+                        raise
+                    biosurl = ''
+            # '' is remembered as 'asked, and there is none'
+            self._varbiosurl = biosurl
+        if not self._varbiosurl:
             raise exc.UnsupportedFunctionality(
                 'Bios management not detected on this platform')
         return self._varbiosurl

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -873,8 +873,24 @@ class Command(object):
     }
 
     async def get_identify(self):
-        await self.sysinfo()
-        ledstate = self.sysinfo
+        sysinfo = await self.sysinfo()
+        ledstate = sysinfo.get('IndicatorLED', None)
+        # The physical indicator belongs to the chassis, and some
+        # implementations do not refresh the system copy of it when it
+        # changes, so prefer a chassis that describes this system alone.
+        for chassis in sysinfo.get('Links', {}).get('Chassis', []):
+            chassisinfo = await self._do_web_request(chassis['@odata.id'])
+            if len(chassisinfo.get('Links', {}).get('ComputerSystems', [])) > 1:
+                continue
+            if chassisinfo.get('IndicatorLED', None) in self._idstatemap:
+                ledstate = chassisinfo['IndicatorLED']
+                break
+        if ledstate is None:
+            raise exc.UnsupportedFunctionality(
+                'Indicator LED state is not reported by this platform')
+        if ledstate not in self._idstatemap:
+            raise exc.PyghmiException(
+                'Unrecognized indicator LED state "{0}"'.format(ledstate))
         return {'identifystate': self._idstatemap[ledstate]}
 
     async def get_health(self, verbose=True):

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1648,6 +1648,20 @@ class Command(object):
         """
         return self._oem.check_storage_configuration(cfgspec)
 
+    # How an implementation says an action it advertised is not there, as
+    # opposed to refusing what was asked of it
+    _absentmsgids = ('ActionNotSupported', 'ResourceMissingAtURI',
+                     'ResourceNotFound')
+
+    def _action_absent(self, theexc):
+        """Whether a failed action call means the action is not served."""
+        msgid = getattr(theexc, 'msgid', None)
+        if msgid is None:
+            # Not a redfish error at all, which is not how one that serves the
+            # action reports refusing
+            return True
+        return any(x in str(msgid) for x in self._absentmsgids)
+
     async def attach_remote_media(self, url, username=None, password=None):
         """Attach remote media by url
 
@@ -1704,7 +1718,11 @@ class Command(object):
                 try:
                     await self._do_web_request(inserturl, {'Image': url})
                     attached = True
-                except (exc.RedfishError, exc.PyghmiException):
+                except exc.PyghmiException as pe:
+                    if not self._action_absent(pe):
+                        # The action is there and refused; that reason is the
+                        # one worth passing on
+                        raise
                     # Some implementations advertise the insert action without
                     # serving it, so fall back to setting the properties
                     inserturl = None

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1316,27 +1316,66 @@ class Command(object):
 
     # A firmware inventory entry says what it belongs to with RelatedItem, so
     # map the collections that turn up there onto the categories confluent asks
-    # for
+    # for.  Only the collections that mean one thing: a Storage resource is the
+    # subsystem rather than a drive, and a Processor is a cpu as readily as an
+    # accelerator, so both are decided further down instead.
     _fwcategorybyurl = (
         ('/Drives/', 'disks'),
-        ('/Storage/', 'disks'),
         ('/PCIeDevices/', 'adapters'),
         ('/NetworkAdapters/', 'adapters'),
         ('/NetworkInterfaces/', 'adapters'),
+        ('/Storage/', 'adapters'),
+        ('/PowerSubsystem/', 'misc'),
+        ('/PowerSupplies/', 'misc'),
+        ('/ThermalSubsystem/', 'misc'),
+        ('/Fans/', 'misc'),
+        ('/Memory/', 'misc'),
     )
 
-    def _fwcategory(self, fwi):
+    # The legacy chassis power and thermal documents, which are a whole path
+    # segment rather than a collection, so they are matched as one.  A bare
+    # substring would also catch a chassis that merely happens to be called
+    # something like PowerShelf1.
+    _fwcategorybysegment = (
+        ('Power', 'misc'),
+        ('Thermal', 'misc'),
+    )
+
+    # What a Processor has to say it is before its firmware counts as a card in
+    # the machine rather than as part of the system
+    _acceleratortypes = ('GPU', 'FPGA', 'Accelerator', 'DSP')
+
+    async def _fwcategory(self, fwi):
         """Which category a firmware inventory entry belongs to.
 
         Returns None when the entry gives nothing to judge by.
         """
-        related = fwi.get('RelatedItem', [])
-        for item in related:
-            url = item.get('@odata.id', '')
+        related = [x.get('@odata.id', '') for x in fwi.get('RelatedItem', [])]
+        for url in related:
             for frag, category in self._fwcategorybyurl:
                 if frag in url:
                     return category
+            lastsegment = url.rstrip('/').rpartition('/')[2]
+            for segment, category in self._fwcategorybysegment:
+                if lastsegment == segment:
+                    return category
+            if '/Processors/' in url:
+                return await self._processorcategory(url)
         return 'core' if related else None
+
+    async def _processorcategory(self, url):
+        """A cpu is system firmware, an accelerator is a card in the machine.
+
+        The url cannot tell them apart, so the processor is asked.  A processor
+        that will not say counts as a cpu, which is the common case and the
+        answer this gave before the distinction was drawn.
+        """
+        try:
+            procinfo = await self._do_web_request(url)
+        except exc.PyghmiException:
+            return 'core'
+        proctype = procinfo.get('ProcessorType', None)
+        return 'adapters' if proctype in self._acceleratortypes else 'core'
 
     async def get_firmware(self, components=(), category=None):
         self._fwnamemap = {}
@@ -1358,7 +1397,7 @@ class Command(object):
                    if res[0]]
         labels = self._firmware_labels(results)
         for res in results:
-            entries.append((self._fwcategory(res[0]),
+            entries.append((await self._fwcategory(res[0]),
                             self._extract_fwinfo(res, labels)))
         for fwcategory, res in entries:
             if res[0] is None:

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -898,6 +898,13 @@ class Command(object):
             raise Exception("Unable to identify system url")
         targinfo = await self._do_web_request(targurl)
         if ('IndicatorLED' not in targinfo
+                and 'LocationIndicatorActive' not in targinfo):
+            # Reading already knows when there is no indicator to speak of, so
+            # do not go on to write a property the platform never offered and
+            # let it answer with whatever it makes of that
+            raise exc.UnsupportedFunctionality(
+                'Indicator LED state is not reported by this platform')
+        if ('IndicatorLED' not in targinfo
                 and 'LocationIndicatorActive' in targinfo):
             # IndicatorLED is deprecated in favour of a boolean, which has no
             # way to ask for blinking, so blinking becomes simply lit

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -908,6 +908,11 @@ class Command(object):
             # The indicator belongs to the chassis and may be described only
             # there, which is where reading looks too.  A shared chassis is
             # somebody else's indicator, as in get_identify.
+            # Only when the system describes none of its own: reading prefers
+            # the chassis, but writing cannot follow it there, because a
+            # platform is free to publish the chassis copy read only.  A
+            # ThinkSystem SD665-N V3 answers PropertyValueFormatError to every
+            # value on Chassis.IndicatorLED and takes all of them on the system.
             for chassis in targinfo.get('Links', {}).get('Chassis', []):
                 chassisinfo = await self._do_web_request(chassis['@odata.id'])
                 if len(chassisinfo.get('Links', {}).get(

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1157,6 +1157,107 @@ class Command(object):
         await self._do_web_request(await self.get_bmcnicurl(),
                              {'HostName': hostname}, 'PATCH', etag='*')
 
+    async def _netprotocolurl(self):
+        bmcinfo = await self._do_web_request(await self.get_bmcurl())
+        netprotocols = bmcinfo.get('NetworkProtocol', {}).get('@odata.id', None)
+        if not netprotocols:
+            raise exc.UnsupportedFunctionality(
+                'This platform does not describe its manager network protocols')
+        return netprotocols
+
+    async def get_mci(self):
+        """Get the management controller identifier
+
+        Redfish has no separate identifier for a management controller the way
+        ipmi does, and the platforms that offer both report the same string for
+        each, so use the name the manager answers to.
+        """
+        netcfg = await self._do_web_request(await self._netprotocolurl())
+        name = netcfg.get('HostName', None)
+        if name is None:
+            raise exc.UnsupportedFunctionality(
+                'This platform does not report a manager identifier')
+        return name
+
+    async def set_mci(self, mci):
+        await self._do_web_request(await self._netprotocolurl(),
+                                   {'HostName': mci}, method='PATCH', etag='*')
+
+    async def get_domain_name(self):
+        netcfg = await self._do_web_request(await self._netprotocolurl())
+        fqdn = netcfg.get('FQDN', None)
+        if not fqdn:
+            return ''
+        # The fqdn is the manager name with the domain appended, and only the
+        # domain part is wanted here
+        hostname = netcfg.get('HostName', None)
+        if hostname and fqdn.startswith(hostname + '.'):
+            return fqdn[len(hostname) + 1:]
+        return fqdn.partition('.')[2]
+
+    async def set_domain_name(self, domain):
+        netprotocols = await self._netprotocolurl()
+        netcfg = await self._do_web_request(netprotocols)
+        hostname = netcfg.get('HostName', '')
+        fqdn = '{0}.{1}'.format(hostname, domain) if domain else hostname
+        await self._do_web_request(netprotocols, {'FQDN': fqdn},
+                                   method='PATCH', etag='*')
+
+    async def get_remote_kvm_available(self):
+        bmcinfo = await self._do_web_request(await self.get_bmcurl())
+        gconsole = bmcinfo.get('GraphicalConsole', {})
+        return bool(gconsole.get('ServiceEnabled', False))
+
+    _ledstatusmap = {
+        'Lit': 'On',
+        'Blinking': 'Blink',
+        'Off': 'Off',
+    }
+
+    async def get_leds(self):
+        """Get LED status information
+
+        Standard redfish only describes the identify indicator, so that is all a
+        platform without an oem specific view of its leds can report.
+        """
+        sysinfo = await self.sysinfo()
+        seen = False
+        for chassis in sysinfo.get('Links', {}).get('Chassis', []):
+            chassisinfo = await self._do_web_request(chassis['@odata.id'])
+            state = chassisinfo.get('IndicatorLED', None)
+            if state is None:
+                continue
+            seen = True
+            yield ('identify', {'status': self._ledstatusmap.get(state, state)})
+            break
+        if not seen and sysinfo.get('IndicatorLED', None) is not None:
+            state = sysinfo['IndicatorLED']
+            yield ('identify', {'status': self._ledstatusmap.get(state, state)})
+
+    # A firmware inventory entry says what it belongs to with RelatedItem, so
+    # map the collections that turn up there onto the categories confluent asks
+    # for
+    _fwcategorybyurl = (
+        ('/Drives/', 'disks'),
+        ('/Storage/', 'disks'),
+        ('/PCIeDevices/', 'adapters'),
+        ('/NetworkAdapters/', 'adapters'),
+        ('/NetworkInterfaces/', 'adapters'),
+    )
+
+    def _fwcategory(self, fwi):
+        """Which category a firmware inventory entry belongs to.
+
+        Returns None when the entry gives nothing to judge by.
+        """
+        related = fwi.get('RelatedItem', [])
+        for item in related:
+            url = item.get('@odata.id', '')
+            for frag, category in self._fwcategorybyurl:
+                if frag in url:
+                    return category
+        return 'core' if related else None
+
     async def get_firmware(self, components=(), category=None):
         self._fwnamemap = {}
         oem = await self.oem()

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1306,6 +1306,10 @@ class Command(object):
         state = None
         for chassis in sysinfo.get('Links', {}).get('Chassis', []):
             chassisinfo = await self._do_web_request(chassis['@odata.id'])
+            if len(chassisinfo.get('Links', {}).get('ComputerSystems', [])) > 1:
+                # A chassis shared with other systems has the enclosure's
+                # indicator rather than this node's, as in get_identify
+                continue
             state = self._indicator_state(chassisinfo)
             if state is not None:
                 break

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -1811,6 +1811,15 @@ class Command(object):
         oem = await self.oem()
         return await oem.get_update_status()   
 
+    async def get_update_types(self):
+        """The kinds of firmware image this platform has to be told about
+
+        Only some implementations will not take an image without being told
+        which kind it is, and those are the ones with an answer here.
+        """
+        oem = await self.oem()
+        return await oem.get_update_types(self)
+
     async def update_firmware(self, file, data=None, progress=None, bank=None, otherfields=()):
         """Send file to BMC to perform firmware update
 

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -945,7 +945,8 @@ class Command(object):
         netprotocols = bmcinfo.get('NetworkProtocol', {}).get('@odata.id', None)
         if netprotocols:
             request = {'NTP':{'ProtocolEnabled': enable}}
-            await self._do_web_request(netprotocols, request, method='PATCH')
+            await self._do_web_request(netprotocols, request, method='PATCH',
+                                       etag='*')
             await self._do_web_request(netprotocols, cache=0)
 
     async def get_ntp_servers(self):
@@ -975,7 +976,8 @@ class Command(object):
                 else:
                     currntpservers[index] = server
         request = {'NTP':{'NTPServers': currntpservers}}
-        await self._do_web_request(netprotocols, request, method='PATCH')
+        await self._do_web_request(netprotocols, request, method='PATCH',
+                                   etag='*')
         await self._do_web_request(netprotocols, cache=0)
 
     async def clear_bmc_configuration(self):
@@ -1047,7 +1049,7 @@ class Command(object):
             }]
         if patch:
             nicurl = await self._get_bmc_nic_url(name)
-            await self._do_web_request(nicurl, patch, 'PATCH')
+            await self._do_web_request(nicurl, patch, 'PATCH', etag='*')
 
     async def set_net_configuration(self, ipv4_address=None, ipv4_configuration=None,
                               ipv4_gateway=None, vlan_id=None, name=None):
@@ -1085,14 +1087,14 @@ class Command(object):
         if patch:
             nicurl = await self._get_bmc_nic_url(name)
             try:
-                await self._do_web_request(nicurl, patch, 'PATCH')
+                await self._do_web_request(nicurl, patch, 'PATCH', etag='*')
             except exc.RedfishError:
                 patch = {'IPv4Addresses': [ipinfo]}
                 if dodhcp:
                     ipinfo['AddressOrigin'] = 'DHCP'
                 elif dodhcp is not None:
                     ipinfo['AddressOrigin'] = 'Static'
-                await self._do_web_request(nicurl, patch, 'PATCH')
+                await self._do_web_request(nicurl, patch, 'PATCH', etag='*')
 
     async def get_net6_configuration(self, name=None):
         nicurl = await self._get_bmc_nic_url(name)
@@ -1147,7 +1149,7 @@ class Command(object):
 
     async def set_hostname(self, hostname):
         await self._do_web_request(await self.get_bmcnicurl(),
-                             {'HostName': hostname}, 'PATCH')
+                             {'HostName': hostname}, 'PATCH', etag='*')
 
     async def get_firmware(self, components=(), category=None):
         self._fwnamemap = {}
@@ -1264,7 +1266,7 @@ class Command(object):
             for chassis in sysinfo.get('Links', {}).get('Chassis', []):
                 chassisurl = chassis['@odata.id']
                 await self._do_web_request(chassisurl, {'Location': locationinfo},
-                                     method='PATCH')
+                                     method='PATCH', etag='*')
 
     async def oem(self):
         if not self._oem:
@@ -1522,11 +1524,11 @@ class Command(object):
                             await self._do_web_request(currl,
                                                        {'Image': None,
                                                         'Inserted': False},
-                                                       method='PATCH')
+                                                       method='PATCH', etag='*')
                         except exc.RedfishError as re:
                             if re.msgid.endswith(u'PropertyUnknown'):
                                 await self._do_web_request(currl, {'Image': None},
-                                                     method='PATCH')
+                                                     method='PATCH', etag='*')
                             else:
                                 raise
         oem = await self.oem()

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -68,6 +68,23 @@ _healthmap = {
     None: const.Health.Ok,
 }
 
+# A sensor from the modern Sensors collection describes itself by its redfish
+# reading type, while a sensor from the older Thermal and Power documents, and
+# every sensor over ipmi, is described by the ipmi sensor type.  Callers ask
+# for a category by the latter, so translate, and a sensor means the same thing
+# whichever document it was read from.
+_readingtypes = {
+    'Temperature': 'Temperature',
+    'Rotational': 'Fan',
+    'AirFlow': 'Cooling Device',
+    'Voltage': 'Voltage',
+    'Current': 'Current',
+    'Power': 'Power',
+    'EnergyJoules': 'Energy',
+    'EnergykWh': 'Energy',
+    'EnergyWh': 'Energy',
+}
+
 
 def _mask_to_cidr(mask):
     maskn = socket.inet_pton(socket.AF_INET, mask)
@@ -719,6 +736,7 @@ class Command(object):
                 sensedata = await self._do_web_request(sensor['@odata.id'])
                 if 'Name' in sensedata:
                     sensetype = sensedata.get('ReadingType', 'Unknown')
+                    sensetype = _readingtypes.get(sensetype, sensetype)
                     self._varsensormap[sensedata['Name']] = {
                         'name': sensedata['Name'], 'type': sensetype,
                         'url': sensor['@odata.id'], 'generic': True}

--- a/confluent_server/aiohmi/redfish/command.py
+++ b/confluent_server/aiohmi/redfish/command.py
@@ -899,6 +899,21 @@ class Command(object):
         targinfo = await self._do_web_request(targurl)
         if ('IndicatorLED' not in targinfo
                 and 'LocationIndicatorActive' not in targinfo):
+            # The indicator belongs to the chassis and may be described only
+            # there, which is where reading looks too.  A shared chassis is
+            # somebody else's indicator, as in get_identify.
+            for chassis in targinfo.get('Links', {}).get('Chassis', []):
+                chassisinfo = await self._do_web_request(chassis['@odata.id'])
+                if len(chassisinfo.get('Links', {}).get(
+                        'ComputerSystems', [])) > 1:
+                    continue
+                if ('IndicatorLED' in chassisinfo
+                        or 'LocationIndicatorActive' in chassisinfo):
+                    targurl = chassis['@odata.id']
+                    targinfo = chassisinfo
+                    break
+        if ('IndicatorLED' not in targinfo
+                and 'LocationIndicatorActive' not in targinfo):
             # Reading already knows when there is no indicator to speak of, so
             # do not go on to write a property the platform never offered and
             # let it answer with whatever it makes of that

--- a/confluent_server/aiohmi/redfish/oem/ami/megarac.py
+++ b/confluent_server/aiohmi/redfish/oem/ami/megarac.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import aiohmi.redfish.oem.generic as generic
 import aiohmi.util.webclient as webclient
 from urllib.parse import urlencode
@@ -54,29 +56,88 @@ class OEMHandler(generic.OEMHandler):
             msgents.append(self.format_messages(msg))
         return ';'.join(msgents)
 
-    async def update_firmware(self, filename, data=None, progress=None, bank=None, otherfields=()):
+    # What to keep across a firmware update, for the builds that let us say.
+    # SDR is excluded because a new firmware image is expected to bring its own.
+    _preserveconfig = {
+        'Syslog': True,
+        'NTP': True,
+        'Network': True,
+        'Authentication': True,
+        'EXTLOG': True,
+        'FRU': True,
+        'IPMI': True,
+        'KVM': True,
+        'REDFISH': True,
+        'SDR': False,
+        'SEL': True,
+        'SNMP': True,
+        'SSH': True,
+        'WEB': True,
+    }
+
+    async def _preserve_configuration(self):
+        """Ask the bmc to keep its configuration across the update.
+
+        Builds differ in which settings they are willing to preserve, and they
+        reject the whole request if it names one they do not know, so send only
+        the intersection with what this bmc advertises.
+        """
+        usd = await self._do_web_request('/redfish/v1/UpdateService', cache=False)
+        advertised = usd.get('Oem', {}).get('AMIUpdateService', {}).get(
+            'PreserveConfiguration', None)
+        if not advertised:
+            return
+        preserve = {k: v for k, v in self._preserveconfig.items() if k in advertised}
+        if not preserve:
+            return
         await self._do_web_request('/redfish/v1/UpdateService', {
-            "Oem": {
-                "AMIUpdateService": {
-                "@odata.type": "#AMIUpdateService.v1_0_0.AMIUpdateService",
-                "PreserveConfiguration": {
-                    "Syslog": True,
-                    "NTP": True,
-                    "Network": True,
-                    "Authentication": True,
-                    "EXTLOG": True,
-                    "FRU": True,
-                    "IPMI": True,
-                    "KVM": True,
-                    "REDFISH": True,
-                    "SDR": False,
-                    "SEL": True,
-                    "SNMP": True,
-                    "SSH": True,
-                    "WEB": True
-            }
-            }}}, method='PATCH', etag='*')
-        return await super().update_firmware(filename, data, progress, bank, otherfields)
+            'Oem': {
+                'AMIUpdateService': {
+                    '@odata.type': '#AMIUpdateService.v1_0_0.AMIUpdateService',
+                    'PreserveConfiguration': preserve,
+                }}}, method='PATCH', etag='*')
+
+    async def _allowed_imagetypes(self):
+        actinfo = await self._do_web_request(
+            '/redfish/v1/UpdateService/SimpleUpdateActionInfo')
+        for param in actinfo.get('Parameters', []):
+            if param.get('Name', None) == 'ImageType':
+                return param.get('AllowableValues', [])
+        return []
+
+    async def _checked_imagetype(self, imagetype, filename):
+        """Check the image type the parameter file gave against what is accepted.
+
+        Flashing the wrong kind of image is not something to be clever about, so
+        the type is asked for rather than worked out from the file.
+        """
+        allowed = await self._allowed_imagetypes()
+        choices = ', '.join(allowed) if allowed else 'BMC, BIOS'
+        if not imagetype:
+            raise pygexc.InvalidParameterValue(
+                'This bmc needs to be told what kind of firmware "{0}" is, '
+                'one of: {1}'.format(os.path.basename(filename), choices))
+        if allowed and imagetype not in allowed:
+            raise pygexc.InvalidParameterValue(
+                '"{0}" is not a firmware image type this bmc accepts, it '
+                'offers: {1}'.format(imagetype, choices))
+        return imagetype
+
+    async def update_firmware(self, filename, data=None, progress=None, bank=None, otherfields=()):
+        await self._preserve_configuration()
+        otherfields = dict(otherfields) if otherfields else {}
+        oemparams = dict(otherfields.get('OemParameters', None) or {})
+        imagetype = await self._checked_imagetype(
+            oemparams.get('ImageType', None), filename)
+        oemparams['ImageType'] = imagetype
+        otherfields['OemParameters'] = oemparams
+        # Updating the bmc takes the bmc away mid flight, which is expected
+        # rather than a failure to watch the update
+        self._updateresetsbmc = imagetype == 'BMC'
+        try:
+            return await super().update_firmware(filename, data, progress, bank, otherfields)
+        finally:
+            self._updateresetsbmc = False
 
 
     async def get_wc(self):

--- a/confluent_server/aiohmi/redfish/oem/ami/megarac.py
+++ b/confluent_server/aiohmi/redfish/oem/ami/megarac.py
@@ -108,13 +108,31 @@ class OEMHandler(generic.OEMHandler):
                     'PreserveConfiguration': preserve,
                 }}}, method='PATCH', etag='*')
 
+    # What the parameter naming the kind of firmware is called in the action
+    # info.  Builds differ, and the names it takes are the same vocabulary as
+    # the OemParameters ImageType a multipart push wants.
+    _imagetypeparams = ('ImageType', 'UpdateComponent')
+
     async def _allowed_imagetypes(self):
-        actinfo = await self._do_web_request(
-            '/redfish/v1/UpdateService/SimpleUpdateActionInfo')
+        try:
+            actinfo = await self._do_web_request(
+                '/redfish/v1/UpdateService/SimpleUpdateActionInfo')
+        except pygexc.PyghmiException:
+            # A build that does not publish the action info still wants an
+            # image type, it just cannot say which names it takes
+            return []
         for param in actinfo.get('Parameters', []):
-            if param.get('Name', None) == 'ImageType':
+            if param.get('Name', None) in self._imagetypeparams:
                 return param.get('AllowableValues', [])
         return []
+
+    async def get_update_types(self, fishclient):
+        allowed = await self._allowed_imagetypes()
+        if not allowed:
+            raise pygexc.UnsupportedFunctionality(
+                'This bmc has to be told what kind of firmware an image holds '
+                'but does not publish the names it accepts')
+        return allowed
 
     async def _checked_imagetype(self, imagetype, filename):
         """Check the image type the parameter file gave against what is accepted.

--- a/confluent_server/aiohmi/redfish/oem/ami/megarac.py
+++ b/confluent_server/aiohmi/redfish/oem/ami/megarac.py
@@ -160,6 +160,9 @@ class OEMHandler(generic.OEMHandler):
             oemparams.get('ImageType', None), filename)
         oemparams['ImageType'] = imagetype
         otherfields['OemParameters'] = oemparams
+        # This firmware rejects a multipart push carrying the image alone.
+        # Empty Targets means "whatever this image is for".
+        otherfields.setdefault('UpdateParameters', {'Targets': []})
         # Updating the bmc takes the bmc away mid flight, which is expected
         # rather than a failure to watch the update
         self._updateresetsbmc = imagetype == 'BMC'

--- a/confluent_server/aiohmi/redfish/oem/ami/megarac.py
+++ b/confluent_server/aiohmi/redfish/oem/ami/megarac.py
@@ -38,14 +38,25 @@ class OEMHandler(generic.OEMHandler):
         self._certverify = webclient.verifycallback
         return self
 
+    # Auxiliary power cycle, offered by the chassis on the megarac based systems
+    # that have an aux power domain to cycle
+    _auxresetaction = '#NvidiaChassis.AuxPowerReset'
+
     async def reseat_bay(self, bay):
         if bay != -1:
             raise pygexc.UnsupportedFunctionality(
                 'This is not an enclosure manager')
-        
-        await self._do_web_request('/redfish/v1/Chassis/Chassis_0/Actions/Oem/NvidiaChassis.AuxPowerReset', {
-            "ResetType": "AuxPowerCycle"
-        })
+        chassiscol = await self._do_web_request('/redfish/v1/Chassis')
+        for chassis in chassiscol.get('Members', []):
+            chassisinfo = await self._do_web_request(chassis['@odata.id'])
+            action = chassisinfo.get('Actions', {}).get('Oem', {}).get(
+                self._auxresetaction, {}).get('target', None)
+            if action:
+                await self._do_web_request(action,
+                                           {'ResetType': 'AuxPowerCycle'})
+                return
+        raise pygexc.UnsupportedFunctionality(
+            'Reseat is not supported on this platform')
 
     def format_messages(self, response):
         msgs = response.get('Messages', [])

--- a/confluent_server/aiohmi/redfish/oem/ami/megarac.py
+++ b/confluent_server/aiohmi/redfish/oem/ami/megarac.py
@@ -168,6 +168,8 @@ class OEMHandler(generic.OEMHandler):
             raise Exception('Failed to authenticate to BMC')
         if 'CSRFToken' in rsp:
             self.csrftok = rsp['CSRFToken']
-            wc.set_header('X-CSRF-Token', rsp['CSRFToken'])
+            # The header MegaRAC checks is spelled without separators; with
+            # X-CSRF-Token every subsequent call answers Invalid Authentication
+            wc.set_header('X-CSRFTOKEN', rsp['CSRFToken'])
         self._wc = wc
         return wc

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -795,7 +795,10 @@ class OEMHandler(object):
                     # that is for
                     break
             await asyncio.sleep(3)
-            if not await fishclient._account_url_info_by_id(uid):
+            # Uncached: a delete that failed left the account collection in the
+            # url cache as it was before, and answering this from that snapshot
+            # could only ever say the account is still there
+            if not await fishclient._account_url_info_by_id(uid, cache=False):
                 return True
         try:
             await fishclient.set_user_password(uid, base64.b64encode(os.urandom(15)))

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -17,6 +17,7 @@ from fnmatch import fnmatch
 import json
 import os
 import re
+import time
 import uuid
 
 import base64
@@ -1427,6 +1428,14 @@ class OEMHandler(object):
     async def update_firmware(self, filename, data=None, progress=None, bank=None, otherfields=()):
         # disable cache to make sure we trigger the token renewal logic if needed
         usd, upurl, ismultipart = await self.retrieve_firmware_upload_url()
+        if ismultipart:
+            # A multipart push has to carry an UpdateParameters part beside the
+            # image, and implementations are entitled to reject the request
+            # when it is missing. Targets empty means "whatever this image is
+            # for", and OperationApplyTime is left out because it is optional
+            # and some implementations refuse the ones they do not implement.
+            otherfields = dict(otherfields) if otherfields else {}
+            otherfields.setdefault('UpdateParameters', {'Targets': []})
         try:
             uploadthread = await webclient.make_uploader(
                 self.webclient, upurl, filename, data, formname='UpdateFile', formwrap=ismultipart,
@@ -1465,6 +1474,20 @@ class OEMHandler(object):
             monitorurl = rsp['@odata.id']
             return await self.monitor_update_progress(monitorurl, progress)
 
+    # How long to keep waiting for a bmc that is expected to restart while it
+    # applies an update to itself. Observed reset to serving again is a bit over
+    # three minutes, so this leaves generous room without hanging forever.
+    _resetgracetime = 300
+
+    async def _bmc_is_back(self):
+        """Check whether the redfish service is serving requests again."""
+        try:
+            rsp, status = await self.webclient.grab_json_response_with_status(
+                '/redfish/v1/')
+        except Exception:
+            return False
+        return status == 200 and bool(rsp)
+
     async def monitor_update_progress(self, monitorurl, progress):
             complete = False
             phase = "apply"
@@ -1473,12 +1496,30 @@ class OEMHandler(object):
             # the validating phase; add a retry here so we don't exit the loop in this case
             retry = 3
             pct = 0.0
+            # Updating the bmc itself takes the bmc, and with it the task we are
+            # watching, away for minutes. That is the update working, not the
+            # monitoring failing, so wait it out and take the bmc coming back
+            # with the task gone as the update having landed.
+            deadline = None
+            if getattr(self, '_updateresetsbmc', False):
+                deadline = time.monotonic() + self._resetgracetime
             while not complete and retry > 0:
                 try:
                     pgress = await self._do_web_request(monitorurl, cache=False)
-                except socket.timeout:
+                except (socket.timeout, exc.PyghmiException, OSError):
                     pgress = None
                 if not pgress:
+                    if deadline is not None:
+                        if time.monotonic() > deadline:
+                            raise Exception(
+                                'The bmc did not return within {0} seconds of '
+                                'starting to apply its firmware'.format(
+                                    self._resetgracetime))
+                        await asyncio.sleep(10)
+                        if await self._bmc_is_back():
+                            progress({'phase': phase, 'progress': 100.0})
+                            return 'pending'
+                        continue
                     retry -= 1
                     await asyncio.sleep(3)
                     continue

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -795,11 +795,18 @@ class OEMHandler(object):
                     # that is for
                     break
             await asyncio.sleep(3)
-            # Uncached: a delete that failed left the account collection in the
-            # url cache as it was before, and answering this from that snapshot
-            # could only ever say the account is still there
-            if not await fishclient._account_url_info_by_id(uid, cache=False):
-                return True
+            try:
+                # Uncached: a delete that failed left the account collection in
+                # the url cache as it was before, and answering this from that
+                # snapshot could only ever say the account is still there
+                if not await fishclient._account_url_info_by_id(uid,
+                                                                cache=False):
+                    return True
+            except Exception:
+                # The check did not answer, which says nothing either way about
+                # the delete.  Ask again rather than letting the failure to
+                # look escape as though it were the failure to delete.
+                pass
         try:
             await fishclient.set_user_password(uid, base64.b64encode(os.urandom(15)))
             await fishclient.set_user_name(uid, '')

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -713,14 +713,33 @@ class OEMHandler(object):
         # Blanking the username seems to be the convention
         # First, set a bogus password in case the implementation does honor
         # blank user, at least render such an account harmless
+        accinfo = await fishclient._account_url_info_by_id(uid)
+        if not accinfo:
+            raise Exception("No such account found")
+        accounturl = accinfo[0]
+        delerr = None
+        # Some implementations take longer to delete an account than they allow
+        # themselves, and report a timeout for a delete that is really underway
+        # or that would work on a second ask, so give the delete another go and
+        # then check whether the account is actually gone before concluding that
+        # this implementation cannot delete at all
+        for _ in range(3):
+            try:
+                await self._do_web_request(accounturl, method='DELETE')
+                return True
+            except Exception as de:
+                if delerr is None:
+                    delerr = de
+            await asyncio.sleep(3)
+            if not await fishclient._account_url_info_by_id(uid):
+                return True
         try:
-            accinfo = await fishclient._account_url_info_by_id(uid)
-            if not accinfo:
-                raise Exception("No such account found")
-            await self._do_web_request(accinfo[0], method='DELETE')
-        except Exception: # fall back to old ipmi-like behavior for such implementations
             await fishclient.set_user_password(uid, base64.b64encode(os.urandom(15)))
-            await fishclient.set_user_name(uid, '')        
+            await fishclient.set_user_name(uid, '')
+        except Exception:
+            # Report why deleting failed rather than why the fallback failed,
+            # since the delete is what was asked for
+            raise delerr
         return True
 
     async def set_bootdev(self, bootdev, persist=False, uefiboot=None,

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -562,12 +562,10 @@ class OEMHandler(object):
                     }
                     yield certdesc
 
-    # A log service whose id or name says one of these is not an event log:
-    # the bmc's own systemd journal, dumps of several kinds, and firmware boot
-    # progress.  Reading them buries the events that were asked for, and
-    # clearing them destroys diagnostic data that has nothing to do with the
-    # event log.
-    noneventlogwords = ('journal', 'dump', 'postcode', 'hostlogger', 'crash')
+    # Words in a log service's id or name that say it holds something other than
+    # events.  Redfish does not settle what a log service is called, so each
+    # handler names its platform's and generic reads every service it finds.
+    noneventlogwords = ()
 
     @classmethod
     def is_event_log(cls, loginfo):

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -549,6 +549,23 @@ class OEMHandler(object):
                     }
                     yield certdesc
 
+    # A log service whose id or name says one of these is not an event log:
+    # the bmc's own systemd journal, dumps of several kinds, and firmware boot
+    # progress.  Reading them buries the events that were asked for, and
+    # clearing them destroys diagnostic data that has nothing to do with the
+    # event log.
+    noneventlogwords = ('journal', 'dump', 'postcode', 'hostlogger', 'crash')
+
+    @classmethod
+    def is_event_log(cls, loginfo):
+        """Say whether a log service holds events rather than something else"""
+        identity = '{0} {1}'.format(loginfo.get('Id', ''),
+                                    loginfo.get('Name', '')).lower()
+        for word in cls.noneventlogwords:
+            if word in identity:
+                return False
+        return True
+
     async def get_event_log(self, clear=False, fishclient=None, extraurls=[]):
         bmcinfo = await self._do_web_request(await fishclient.get_bmcurl())
         lsurl = bmcinfo.get('LogServices', {}).get('@odata.id', None)
@@ -566,10 +583,41 @@ class OEMHandler(object):
                 correction = now - currtime
             except TypeError:
                 correction = now - currtime.replace(tzinfo=utz)
-        lurls = (await self._do_web_request(lsurl)).get('Members', [])
-        lurls.extend(extraurls)
+
+        async def eventlogurls(lscollection):
+            """The log services in a collection that hold events"""
+            found = []
+            lscol = await self._do_web_request(lscollection)
+            for member in lscol.get('Members', []):
+                candidate = member['@odata.id']
+                try:
+                    loginfo = await self._do_web_request(candidate,
+                                                         cache=(not clear))
+                except Exception:
+                    # leave it in, so the loop below reports it as unreadable
+                    found.append(candidate)
+                    continue
+                if self.is_event_log(loginfo):
+                    found.append(candidate)
+            return found
+
+        lurls = await eventlogurls(lsurl)
+        if not lurls:
+            # Some implementations keep no event log under the manager and put
+            # it under the system instead, so fall back to looking there rather
+            # than answering with nothing at all.
+            for sysurl in self._allsysurls:
+                currsysinfo = await self._do_web_request(sysurl)
+                syslsurl = currsysinfo.get('LogServices', {}).get(
+                    '@odata.id', None)
+                if syslsurl:
+                    lurls.extend(await eventlogurls(syslsurl))
+        lurls.extend([x['@odata.id'] for x in extraurls])
+        seenurls = set()
         for lurl in lurls:
-            lurl = lurl['@odata.id']
+            if lurl in seenurls:
+                continue
+            seenurls.add(lurl)
             try:
                 loginfo = await self._do_web_request(lurl, cache=(not clear))
             except Exception:
@@ -580,7 +628,6 @@ class OEMHandler(object):
                 record['timestamp'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
                 yield record
                 continue
-            loginfo = await self._do_web_request(lurl, cache=(not clear))
             entriesurl = loginfo.get('Entries', {}).get('@odata.id', None)
             if not entriesurl:
                 continue

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -32,6 +32,19 @@ from datetime import timedelta
 from dateutil import tz
 import socket
 
+
+def _maybe_transient(theexc):
+    """Whether a request might succeed if it were simply asked again.
+
+    A bmc that answered and refused has given its answer.  Only one that did
+    not answer, or said it ran out of time, is worth asking twice.
+    """
+    if isinstance(theexc, (asyncio.TimeoutError, OSError)):
+        return True
+    text = str(theexc).lower()
+    return 'timeout' in text or 'timed out' in text
+
+
 def _pem_to_dict(pemdata, uefi=False):
     """Pull PEM into a dict
 
@@ -777,6 +790,10 @@ class OEMHandler(object):
             except Exception as de:
                 if delerr is None:
                     delerr = de
+                if not _maybe_transient(de):
+                    # It answered and refused, and the fallback below is what
+                    # that is for
+                    break
             await asyncio.sleep(3)
             if not await fishclient._account_url_info_by_id(uid):
                 return True

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -1458,7 +1458,8 @@ class OEMHandler(object):
             if 'HttpPushUriTargetsBusy' in usd:
                 await self._do_web_request(
                     '/redfish/v1/UpdateService',
-                    {'HttpPushUriTargetsBusy': False}, method='PATCH')
+                    {'HttpPushUriTargetsBusy': False}, method='PATCH',
+                    etag='*')
 
     async def continue_update(self, rsp, progress):
             monitorurl = rsp['@odata.id']
@@ -1524,7 +1525,8 @@ class OEMHandler(object):
                 raise exc.UnsupportedFunctionality('Redfish firmware update only supported for implementations with push update support')
             if 'HttpPushUriTargetsBusy' in usd:
                 await self._do_web_request('/redfish/v1/UpdateService',
-                    {'HttpPushUriTargetsBusy': True}, method='PATCH')
+                    {'HttpPushUriTargetsBusy': True}, method='PATCH',
+                    etag='*')
                     
         return usd,upurl,ismultipart
 

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -1620,9 +1620,11 @@ class OEMHandler(object):
             # watching, away for minutes. That is the update working, not the
             # monitoring failing, so wait it out and take the bmc coming back
             # with the task gone as the update having landed.
+            expectsreset = getattr(self, '_updateresetsbmc', False)
+            # Started when the bmc actually goes, not now: a flash that keeps
+            # answering for longer than the grace period would otherwise have
+            # spent it all before the reboot it is meant to cover.
             deadline = None
-            if getattr(self, '_updateresetsbmc', False):
-                deadline = time.monotonic() + self._resetgracetime
             wentaway = False
             while not complete and retry > 0:
                 try:
@@ -1630,8 +1632,10 @@ class OEMHandler(object):
                 except (socket.timeout, exc.PyghmiException, OSError):
                     pgress = None
                 if not pgress:
-                    if deadline is not None:
-                        if time.monotonic() > deadline:
+                    if expectsreset:
+                        if deadline is None:
+                            deadline = time.monotonic() + self._resetgracetime
+                        elif time.monotonic() > deadline:
                             raise Exception(
                                 'The bmc did not finish applying its firmware '
                                 'within {0} seconds'.format(

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -990,8 +990,8 @@ class OEMHandler(object):
     async def detach_remote_media(self):
         return None
 
-    async def get_description(self):
-        sysinfo = await self.sysinfo()
+    async def get_description(self, fishclient):
+        sysinfo = await fishclient.sysinfo()
         for chassis in sysinfo.get('Links', {}).get('Chassis', []):
             chassisurl = chassis['@odata.id']
             chassisinfo = await self._do_web_request(chassisurl)

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -1586,6 +1586,7 @@ class OEMHandler(object):
             deadline = None
             if getattr(self, '_updateresetsbmc', False):
                 deadline = time.monotonic() + self._resetgracetime
+            wentaway = False
             while not complete and retry > 0:
                 try:
                     pgress = await self._do_web_request(monitorurl, cache=False)
@@ -1595,11 +1596,17 @@ class OEMHandler(object):
                     if deadline is not None:
                         if time.monotonic() > deadline:
                             raise Exception(
-                                'The bmc did not return within {0} seconds of '
-                                'starting to apply its firmware'.format(
+                                'The bmc did not finish applying its firmware '
+                                'within {0} seconds'.format(
                                     self._resetgracetime))
                         await asyncio.sleep(10)
-                        if await self._bmc_is_back():
+                        if not await self._bmc_is_back():
+                            # Going away is what taking the update looks like,
+                            # so only a bmc that went away can come back with
+                            # it applied.  Losing the task while it answers is
+                            # a fault, reported at the deadline.
+                            wentaway = True
+                        elif wentaway:
                             progress({'phase': phase, 'progress': 100.0})
                             return 'pending'
                         continue

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -1548,14 +1548,6 @@ class OEMHandler(object):
     async def update_firmware(self, filename, data=None, progress=None, bank=None, otherfields=()):
         # disable cache to make sure we trigger the token renewal logic if needed
         usd, upurl, ismultipart = await self.retrieve_firmware_upload_url()
-        if ismultipart:
-            # A multipart push has to carry an UpdateParameters part beside the
-            # image, and implementations are entitled to reject the request
-            # when it is missing. Targets empty means "whatever this image is
-            # for", and OperationApplyTime is left out because it is optional
-            # and some implementations refuse the ones they do not implement.
-            otherfields = dict(otherfields) if otherfields else {}
-            otherfields.setdefault('UpdateParameters', {'Targets': []})
         try:
             uploadthread = await webclient.make_uploader(
                 self.webclient, upurl, filename, data, formname='UpdateFile', formwrap=ismultipart,

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -1356,7 +1356,24 @@ class OEMHandler(object):
             if onlynames:
                 yield name
                 continue
-            cpuinfo = {'Model': currcpuinfo.get('Model', None)}
+            # Only when the bmc says so, since a processor that does not
+            # describe its state at all is not thereby missing
+            if currcpuinfo.get('Status', {}).get('State', '') == 'Absent':
+                yield (name, None)
+                continue
+            # A model alone leaves nothing to report on a platform that does
+            # not give one, and the rest of this is what a caller asking after
+            # a processor wants to know anyway
+            cpuinfo = {
+                'Model': currcpuinfo.get('Model', None),
+                'Manufacturer': currcpuinfo.get('Manufacturer', None),
+                'Socket': currcpuinfo.get('Socket', None),
+                'Cores': currcpuinfo.get('TotalCores', None),
+                'Threads': currcpuinfo.get('TotalThreads', None),
+                'Max Speed MHz': currcpuinfo.get('MaxSpeedMHz', None),
+                'Serial Number': currcpuinfo.get('SerialNumber', None),
+                'Part Number': currcpuinfo.get('PartNumber', None),
+            }
             yield name, cpuinfo
 
     async def _get_disk_urls(self):

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -1661,15 +1661,18 @@ class OEMHandler(object):
         overview = await fishclient._do_web_request('/redfish/v1/')
         licsrv = overview.get('LicenseService', {}).get('@odata.id', None)
         if not licsrv:
-            raise exc.UnsupportedFunctionality()
+            raise exc.UnsupportedFunctionality(
+                'This platform does not implement the redfish license service')
         lcs = await fishclient._do_web_request(licsrv)
         licenses = lcs.get('Licenses', {}).get('@odata.id',None)
         if not licenses:
-            raise exc.UnsupportedFunctionality()
+            raise exc.UnsupportedFunctionality(
+                'This platform does not offer a redfish license collection')
         return licenses
 
-    def get_extended_bmc_configuration(self, fishclient, hideadvanced=True):
-        raise exc.UnsupportedFunctionality()
+    async def get_extended_bmc_configuration(self, fishclient, hideadvanced=True):
+        raise exc.UnsupportedFunctionality(
+            'Extended bmc configuration is not supported on this platform')
 
 
     async def _get_licenses(self, fishclient):

--- a/confluent_server/aiohmi/redfish/oem/generic.py
+++ b/confluent_server/aiohmi/redfish/oem/generic.py
@@ -1525,6 +1525,16 @@ class OEMHandler(object):
         msgs = response.get('Messages', [])
         return ';'.join(self.format_message(x) for x in msgs)
 
+    async def get_update_types(self, fishclient):
+        """The kinds of firmware image this platform has to be told about.
+
+        A platform that reads the kind from the image has none to report, which
+        is not the same as failing to answer.
+        """
+        raise exc.UnsupportedFunctionality(
+            'This platform does not take a firmware image type, it reads the '
+            'kind of firmware from the image')
+
     async def update_firmware(self, filename, data=None, progress=None, bank=None, otherfields=()):
         # disable cache to make sure we trigger the token renewal logic if needed
         usd, upurl, ismultipart = await self.retrieve_firmware_upload_url()

--- a/confluent_server/aiohmi/redfish/oem/lookup.py
+++ b/confluent_server/aiohmi/redfish/oem/lookup.py
@@ -39,9 +39,25 @@ async def get_oem_handler(sysinfo, sysurl, webclient, cache, cmd, rootinfo={}):
         if oem in OEMMAP:
             return await OEMMAP[oem].get_handler(sysinfo, sysurl, webclient, cache,
                                                  cmd, rootinfo)
-    if rootinfo:  # rootinfo indicates early invocation, bmcinfo not ready yet
-        return await generic.OEMHandler.create(sysinfo, sysurl, webclient, cache, cmd._gpool, rootinfo)
-    bmcinfo = await cmd.bmcinfo()
+    # The manager document names the vendor on implementations that do not say
+    # so at the service root or on the system, so consult it before settling for
+    # generic. During the early invocation the client cannot fetch it through
+    # cmd yet, so ask for it directly.
+    bmcinfo = {}
+    if rootinfo:
+        managers = rootinfo.get('Managers', {}).get('@odata.id', None)
+        if managers:
+            mgrcol, status = await webclient.grab_json_response_with_status(
+                managers)
+            if status == 200:
+                for manager in mgrcol.get('Members', []):
+                    mgrinfo, status = await webclient.grab_json_response_with_status(
+                        manager['@odata.id'])
+                    if status == 200:
+                        bmcinfo = mgrinfo
+                    break
+    else:
+        bmcinfo = await cmd.bmcinfo()
     for oem in bmcinfo.get('Oem', {}):
         if oem in OEMMAP:
             return await OEMMAP[oem].get_handler(sysinfo, sysurl, webclient, cache,

--- a/confluent_server/aiohmi/redfish/oem/lookup.py
+++ b/confluent_server/aiohmi/redfish/oem/lookup.py
@@ -17,6 +17,7 @@ import aiohmi.redfish.oem.generic as generic
 import aiohmi.redfish.oem.lenovo.main as lenovo
 import aiohmi.redfish.oem.ami.main as ami
 import aiohmi.redfish.oem.megware.main as megware
+import aiohmi.redfish.oem.openbmc.main as openbmc
 
 OEMMAP = {
     'Lenovo': lenovo,
@@ -24,6 +25,9 @@ OEMMAP = {
     'AMI': ami,
     'Ami': ami,
     'Megware': megware,
+    # bmcweb spells its oem key OpenBmc on the manager and OpenBMC elsewhere
+    'OpenBMC': openbmc,
+    'OpenBmc': openbmc,
 }
 
 

--- a/confluent_server/aiohmi/redfish/oem/openbmc/main.py
+++ b/confluent_server/aiohmi/redfish/oem/openbmc/main.py
@@ -1,0 +1,24 @@
+# Copyright 2026 MEGWARE Computer Vertrieb und Service GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+OEM handler for the OpenBMC (bmcweb) redfish service.
+"""
+
+import aiohmi.redfish.oem.openbmc.openbmc as openbmc
+
+
+async def get_handler(sysinfo, sysurl, webclient, cache, cmd, rootinfo={}):
+    return await openbmc.OEMHandler.create(sysinfo, sysurl, webclient, cache,
+                                           gpool=cmd._gpool, rootinfo=rootinfo)

--- a/confluent_server/aiohmi/redfish/oem/openbmc/openbmc.py
+++ b/confluent_server/aiohmi/redfish/oem/openbmc/openbmc.py
@@ -1,0 +1,22 @@
+# Copyright 2026 MEGWARE Computer Vertrieb und Service GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import aiohmi.redfish.oem.generic as generic
+
+
+class OEMHandler(generic.OEMHandler):
+    # bmcweb keeps its journal, dumps, post codes and console capture under the
+    # manager and the event log under the system, so reading those buries the
+    # events asked for and clearing them destroys diagnostic data.
+    noneventlogwords = ('journal', 'dump', 'postcode', 'hostlogger', 'crash')

--- a/confluent_server/confluent/config/configmanager.py
+++ b/confluent_server/confluent/config/configmanager.py
@@ -105,6 +105,9 @@ _initlock = asyncio.Lock()
 _followerlocks = {}
 _config_areas = ('nodegroups', 'nodes', 'usergroups', 'users')
 tracelog = None
+# How to stop the service when a client asks for a shutdown. The running
+# service registers this, since only it knows how to unwind itself.
+_shutdownhook = None
 statelessmode = False
 _cfgstore = None
 _pendingchangesets = {}
@@ -143,6 +146,12 @@ def attrib_supports_expression(attrib):
     if attrib.startswith('secret.') or attrib.startswith('crypted.') or attrib.startswith('custom.nodesecret.'):
         return False
     return True
+
+
+def set_shutdown_hook(hook):
+    """Register how the running service should be asked to stop."""
+    global _shutdownhook
+    _shutdownhook = hook
 
 
 def _mkpath(pathname):
@@ -2884,6 +2893,12 @@ class ConfigManager(object):
 
     @classmethod
     def shutdown(cls):
+        if _shutdownhook is not None:
+            # The service knows how to stop itself in an orderly way, including
+            # flushing configuration, and raising SystemExit from here would go
+            # through a running event loop, which asyncio cannot recover from
+            _shutdownhook()
+            return
         cls.wait_for_sync()
         sys.exit(0)
 

--- a/confluent_server/confluent/core.py
+++ b/confluent_server/confluent/core.py
@@ -557,6 +557,10 @@ def _init_core():
                     'pluginattrs': ['hardwaremanagement.method'],
                     'default': 'null',
                 }),
+                'updatetypes': PluginRoute({
+                    'pluginattrs': ['hardwaremanagement.method'],
+                    'default': 'null',
+                }),
                 'updates': {
                     'active': PluginCollection({
                             'pluginattrs': ['hardwaremanagement.method'],

--- a/confluent_server/confluent/exceptions.py
+++ b/confluent_server/confluent/exceptions.py
@@ -19,6 +19,19 @@ import base64
 import json
 import msgpack
 
+def exc_text(theexc):
+    """Render an exception for a user, even when it carries no message.
+
+    An error with no text at all tells the user nothing, so fall back to the
+    description a confluent exception carries by class, and then to the name of
+    the exception.
+    """
+    text = str(theexc)
+    if text and text != 'None':
+        return text
+    return getattr(theexc, '_apierrorstr', None) or type(theexc).__name__
+
+
 def deserialize_exc(msg):
     excd = msgpack.unpackb(msg, raw=False)
     if excd[0] == 'Exception':
@@ -35,8 +48,7 @@ class ConfluentException(Exception):
     _apierrorstr = 'Unexpected Error'
 
     def get_error_body(self):
-        errstr = ' - '.join((self._apierrorstr, str(self)))
-        return json.dumps({'error': errstr })
+        return json.dumps({'error': self.apierrorstr})
 
     def serialize(self):
         return msgpack.packb([self.__class__.__name__, [str(self)]],

--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -207,6 +207,12 @@ def request_stop():
         _stopevent.set()
 
 
+def _finish_shutdown():
+    """Say the service is going and get the configuration on disk."""
+    log.log({'info': 'Confluent management service shutting down'}, flush=True)
+    configmanager.ConfigManager.wait_for_sync()
+
+
 def terminate(signalname, frame):
     # Only for platforms where the event loop cannot deliver signals for us.
     # Raising SystemExit from a handler while the loop runs escapes run_forever
@@ -369,14 +375,26 @@ async def asyncrun(args):
         pass
     webservice = httpapi.HttpApi(http_bind_host, http_bind_port, http_bind_group, http_bind_perms)
     webservice.start()
-    while len(list(configmanager.list_collective())) >= 2:
+    while not _stopevent.is_set() and len(
+            list(configmanager.list_collective())) >= 2:
         # If in a collective, stall automatic startup activity
         # until we establish quorum
         try:
             configmanager.check_quorum()
             break
         except Exception:
-            await asyncio.sleep(0.5)
+            # Waiting on the stop event rather than sleeping through it.  A
+            # member that cannot reach quorum stalls here for as long as that
+            # lasts, and asking it to stop has to be answered in that state
+            # rather than after quorum returns.
+            try:
+                await asyncio.wait_for(_stopevent.wait(), 0.5)
+            except asyncio.TimeoutError:
+                pass
+    if _stopevent.is_set():
+        # Asked to stop before startup got as far as serving anything, so
+        # there is nothing to unwind beyond what stopping normally does
+        return _finish_shutdown()
     disco.start_detection()
     await asyncio.sleep(1)
     await consoleserver.start_console_sessions()
@@ -400,8 +418,7 @@ async def asyncrun(args):
             break
         if notifysock:
             sock.send(b'WATCHDOG=1')
-    log.log({'info': 'Confluent management service shutting down'}, flush=True)
-    configmanager.ConfigManager.wait_for_sync()
+    _finish_shutdown()
 
 def _get_connector_config(session):
     host = conf.get_option(session, 'bindhost')

--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -230,10 +230,15 @@ def doexit():
         os.remove('/var/run/confluent/dbg.sock')
     except OSError:
         pass
-    pidfile = open('/var/run/confluent/pid')
-    pid = pidfile.read()
-    if pid == str(os.getpid()):
-        os.remove('/var/run/confluent/pid')
+    try:
+        with open('/var/run/confluent/pid') as pidfile:
+            pid = pidfile.read()
+        if pid == str(os.getpid()):
+            os.remove('/var/run/confluent/pid')
+    except OSError:
+        # Someone else already tidied it up, which is not worth a traceback out
+        # of an atexit callback
+        pass
 
 
 def _initsecurity(config):

--- a/confluent_server/confluent/main.py
+++ b/confluent_server/confluent/main.py
@@ -194,7 +194,24 @@ def _checkpidfile():
         pidfile.close()
 
 
+_stopevent = None
+
+
+def request_stop():
+    """Ask the service to shut down.
+
+    Called from the event loop, either by a signal handler or by a client
+    asking for a shutdown, so it only has to wake the main coroutine.
+    """
+    if _stopevent is not None:
+        _stopevent.set()
+
+
 def terminate(signalname, frame):
+    # Only for platforms where the event loop cannot deliver signals for us.
+    # Raising SystemExit from a handler while the loop runs escapes run_forever
+    # and leaves asyncio unable to close the loop, which is why the loop is
+    # asked to stop instead wherever that is possible.
     sys.exit(0)
 
 def dumptrace(signalname, frame):
@@ -319,8 +336,14 @@ async def asyncrun(args):
     if havefcntl:
         _updatepidfile()
     asyncio.get_running_loop().set_debug(True)
-    signal.signal(signal.SIGINT, terminate)
-    signal.signal(signal.SIGTERM, terminate)
+    global _stopevent
+    _stopevent = asyncio.Event()
+    for stopsig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            asyncio.get_running_loop().add_signal_handler(stopsig, request_stop)
+        except NotImplementedError:  # silly windows
+            signal.signal(stopsig, terminate)
+    configmanager.set_shutdown_hook(request_stop)
     atexit.register(doexit)
     confluentuuid = configmanager.get_global('confluent_uuid')
     if not confluentuuid:
@@ -363,10 +386,17 @@ async def asyncrun(args):
     if not watchdogsecs:
         watchdogsecs = 200
     watchdogsecs = watchdogsecs / 2
-    while 1:
-        await asyncio.sleep(watchdogsecs)
+    while not _stopevent.is_set():
+        try:
+            await asyncio.wait_for(_stopevent.wait(), watchdogsecs)
+        except asyncio.TimeoutError:
+            pass
+        else:
+            break
         if notifysock:
             sock.send(b'WATCHDOG=1')
+    log.log({'info': 'Confluent management service shutting down'}, flush=True)
+    configmanager.ConfigManager.wait_for_sync()
 
 def _get_connector_config(session):
     host = conf.get_option(session, 'bindhost')

--- a/confluent_server/confluent/messages.py
+++ b/confluent_server/confluent/messages.py
@@ -584,9 +584,9 @@ def get_input_message(path, operation, inputdata, nodes=None, multinode=False,
     elif '/'.join(path).startswith('media/') and inputdata:
         return InputMedia(path, nodes, inputdata, configmanager)
     elif '/'.join(path).startswith('support/servicedata') and inputdata:
-        return InputMedia(path, nodes, inputdata, configmanager)
+        return InputDownloadTarget(path, nodes, inputdata, configmanager)
     elif '/'.join(path).startswith('configuration/management_controller/save_licenses') and inputdata:
-        return InputMedia(path, nodes, inputdata, configmanager)
+        return InputDownloadTarget(path, nodes, inputdata, configmanager)
     elif '/'.join(path).startswith(
             'configuration/management_controller/licenses') and inputdata:
         return InputLicense(path, nodes, inputdata, configmanager)
@@ -631,6 +631,9 @@ def isurl(value):
 
 class InputFirmwareUpdate(ConfluentMessage):
     urlsupported = False
+    # Whether the named file is something confluent will read from the caller,
+    # or somewhere confluent is being asked to write to
+    isdownload = False
     def __init__(self, path, nodes, inputdata, configmanager):
         self._filename = inputdata.get('filename', inputdata.get('url', inputdata.get('dirname', None)))
         self.bank = inputdata.get('bank', None)
@@ -660,7 +663,8 @@ class InputFirmwareUpdate(ConfluentMessage):
                 if value.startswith('/var/log/confluent'):
                     raise Exception(
                         'File transfer with /var/log/confluent is not supported')
-                if curruser and not value.startswith('/var/lib/confluent/client_assets/'):
+                if (curruser and not self.isdownload
+                        and not value.startswith('/var/lib/confluent/client_assets/')):
                     try:
                         pwent = pwd.getpwnam(curruser)
                         if not checkaccess(curruser, value, pwent):
@@ -699,6 +703,12 @@ class InputFirmwareUpdate(ConfluentMessage):
             raise Exception(
                 'File transfer with /var/log/confluent is not supported')
         return self.filebynode[node]
+
+class InputDownloadTarget(InputFirmwareUpdate):
+    # Where to save something confluent fetches, so the path is a destination
+    # rather than a file that has to exist and be readable already
+    isdownload = True
+
 
 class InputMedia(InputFirmwareUpdate):
     # Use InputFirmwareUpdate

--- a/confluent_server/confluent/messages.py
+++ b/confluent_server/confluent/messages.py
@@ -687,6 +687,15 @@ class InputFirmwareUpdate(ConfluentMessage):
                                     '{0} is not writable by {1}, check the '
                                     'directory and parent directory ownership '
                                     'and permissions'.format(target, curruser))
+                            if target != value and os.path.exists(value):
+                                # /tmp lets anyone create a file, which says
+                                # nothing about one already sitting there
+                                if not checkaccess(curruser, value, pwent,
+                                                   os.W_OK):
+                                    raise Exception(
+                                        '{0} already exists and is not writable '
+                                        'by {1}, check the file ownership and '
+                                        'permissions'.format(value, curruser))
                         elif not checkaccess(curruser, value, pwent):
                             errstr = '{0} is not readable by {1}, check the file and parent directory ownership and permissions'.format(
                                 value, curruser)

--- a/confluent_server/confluent/messages.py
+++ b/confluent_server/confluent/messages.py
@@ -592,18 +592,21 @@ def get_input_message(path, operation, inputdata, nodes=None, multinode=False,
             'No known input handler for request')
 
 
-def checkaccess(user, filename, pwent):
-    """Check if a user has read access to a file.
+def checkaccess(user, filename, pwent, mode=os.R_OK):
+    """Check if a user has the given access to a path.
 
-    This function checks if the specified user has read access to the given
-    filename. It returns True if the user has read access, and False otherwise.
+    This function checks if the specified user has the access named by mode to
+    the given filename. It returns True if the user has it, False otherwise.
+    Use R_OK to ask whether the user could have read a file they want confluent
+    to send, and W_OK on a directory to ask whether they could have created a
+    file where they want confluent to save one.
     """
     child = os.fork()
     if child == 0:
         os.setgroups(os.getgrouplist(user, pwent.pw_gid))
         os.setgid(pwent.pw_gid)
         os.setuid(pwent.pw_uid)
-        if os.access(filename, os.R_OK):
+        if os.access(filename, mode):
             os._exit(0)
         os._exit(1)
     else:
@@ -617,6 +620,18 @@ def isurl(value):
     if '/' in prefix:
         return False
     return True if prefix else False
+
+
+def destdir(value):
+    """The directory a download will actually be written into.
+
+    A path that is already a directory is a destination directory and the file
+    gets created inside it; anything else names the file itself. This is the
+    same rule the code that writes the file goes by.
+    """
+    if os.path.isdir(value):
+        return value
+    return os.path.dirname(value) or '.'
 
 class InputFirmwareUpdate(ConfluentMessage):
     urlsupported = False
@@ -652,11 +667,24 @@ class InputFirmwareUpdate(ConfluentMessage):
                 if value.startswith('/var/log/confluent'):
                     raise Exception(
                         'File transfer with /var/log/confluent is not supported')
-                if (curruser and not self.isdownload
+                if (curruser
                         and not value.startswith('/var/lib/confluent/client_assets/')):
                     try:
                         pwent = pwd.getpwnam(curruser)
-                        if not checkaccess(curruser, value, pwent):
+                        if self.isdownload:
+                            # Asking whether a destination can be read fails for
+                            # every file that does not exist yet, which is most
+                            # of them.  The question that carries the same
+                            # meaning here is whether the user could have
+                            # created the file there themselves.
+                            target = destdir(value)
+                            if not checkaccess(curruser, target, pwent,
+                                               os.W_OK):
+                                raise Exception(
+                                    '{0} is not writable by {1}, check the '
+                                    'directory and parent directory ownership '
+                                    'and permissions'.format(target, curruser))
+                        elif not checkaccess(curruser, value, pwent):
                             errstr = '{0} is not readable by {1}, check the file and parent directory ownership and permissions'.format(
                                 value, curruser)
                             raise Exception(errstr)

--- a/confluent_server/confluent/messages.py
+++ b/confluent_server/confluent/messages.py
@@ -681,8 +681,12 @@ class InputFirmwareUpdate(ConfluentMessage):
                             # meaning here is whether the user could have
                             # created the file there themselves.
                             target = destdir(value)
+                            # Search as well as write: a directory the user can
+                            # write but not enter is one they cannot create a
+                            # file in, and os.access says nothing about that on
+                            # its own
                             if not checkaccess(curruser, target, pwent,
-                                               os.W_OK):
+                                               os.W_OK | os.X_OK):
                                 raise Exception(
                                     '{0} is not writable by {1}, check the '
                                     'directory and parent directory ownership '

--- a/confluent_server/confluent/messages.py
+++ b/confluent_server/confluent/messages.py
@@ -543,6 +543,9 @@ def get_input_message(path, operation, inputdata, nodes=None, multinode=False,
     elif (path[:3] == ['configuration', 'management_controller', 'domain_name']
             and operation != 'retrieve'):
         return InputDomainName(path, nodes, inputdata)
+    elif (path[:3] == ['configuration', 'management_controller', 'location']
+            and operation != 'retrieve'):
+        return InputAttributes(path, inputdata, nodes)
     elif (path[:4] == ['configuration', 'management_controller', 'ntp',
             'enabled'] and operation != 'retrieve'):
         return InputNTPEnabled(path, nodes, inputdata)

--- a/confluent_server/confluent/messages.py
+++ b/confluent_server/confluent/messages.py
@@ -238,10 +238,14 @@ class ConfluentMessage(object):
 
 class ConfluentNodeError(object):
     apicode = 500
+    # What to say when the caller had no text to offer.  An error that reads
+    # "None" tells a user nothing, and every route out of here, the api body,
+    # the html and the exception strip_node raises, wants something to print.
+    defaulterror = 'Unknown error'
 
-    def __init__(self, node, errorstr):
+    def __init__(self, node, errorstr=None):
         self.node = node
-        self.error = errorstr
+        self.error = errorstr if errorstr else self.defaulterror
 
     def serialize(self):
         return msgpack.packb(
@@ -267,10 +271,7 @@ class ConfluentNodeError(object):
 
 class NotImplemented(ConfluentNodeError):
     apicode = 501
-
-    def __init__(self, node, errorstr='Not implemented'):
-        self.node = node
-        self.error = errorstr
+    defaulterror = 'Not implemented'
 
 class Generic(ConfluentMessage):
 
@@ -289,10 +290,7 @@ class Generic(ConfluentMessage):
 
 class ConfluentResourceUnavailable(ConfluentNodeError):
     apicode = 503
-
-    def __init__(self, node, errstr='Unavailable'):
-        self.node = node
-        self.error = errstr
+    defaulterror = 'Unavailable'
 
     def strip_node(self, node):
         raise exc.TargetResourceUnavailable()
@@ -300,11 +298,7 @@ class ConfluentResourceUnavailable(ConfluentNodeError):
 
 class ConfluentTargetTimeout(ConfluentNodeError):
     apicode = 504
-
-    def __init__(self, node, errstr='timeout'):
-        self.node = node
-        self.error = errstr
-
+    defaulterror = 'timeout'
 
     def strip_node(self, node):
         raise exc.TargetEndpointUnreachable(self.error)
@@ -312,10 +306,7 @@ class ConfluentTargetTimeout(ConfluentNodeError):
 
 class ConfluentTargetNotFound(ConfluentNodeError):
     apicode = 404
-
-    def __init__(self, node, errorstr='not found'):
-        self.node = node
-        self.error = errorstr
+    defaulterror = 'not found'
 
     def strip_node(self, node):
         raise exc.NotFoundException(self.error)
@@ -323,9 +314,7 @@ class ConfluentTargetNotFound(ConfluentNodeError):
 
 class ConfluentTargetInvalidCredentials(ConfluentNodeError):
     apicode = 502
-    def __init__(self, node, errstr='bad credentials'):
-        self.node = node
-        self.error = errstr
+    defaulterror = 'bad credentials'
 
     def strip_node(self, node):
         raise exc.TargetEndpointBadCredentials

--- a/confluent_server/confluent/plugins/console/openbmc.py
+++ b/confluent_server/confluent/plugins/console/openbmc.py
@@ -20,13 +20,33 @@
 # to use this.
 
 import asyncio
+import traceback
 import confluent.exceptions as cexc
 import confluent.interface.console as conapi
+import confluent.log as log
 import confluent.tasks as tasks
 import confluent.util as util
 import aiohmi.exceptions as pygexc
 import aiohmi.util.webclient as webclient
 import aiohttp
+
+_tracelog = None
+
+
+def _trace(text, event=log.Events.stacktrace):
+    """Record a console problem where an operator can find it.
+
+    A daemon has nowhere useful to print to, and printing once per message
+    received is how a websocket that had already gone away managed to write
+    gigabytes of a single line.
+    """
+    global _tracelog
+    if _tracelog is None:
+        # Unbuffered: this records a console that has just gone away, and
+        # the daemon may not survive long enough to flush a buffered write.
+        _tracelog = log.Logger('trace', buffered=False)
+    _tracelog.log(text, ltype=log.DataTypes.event, event=event)
+
 
 class CustomVerifier(aiohttp.Fingerprint):
     def __init__(self, verifycallback):
@@ -83,6 +103,7 @@ class OpenBmcConsole(conapi.Console):
         self.nodeconfig = config
         self.connected = False
         self.recvr = None
+        self.clisess = None
 
 
     async def recvdata(self):
@@ -92,11 +113,23 @@ class OpenBmcConsole(conapi.Console):
                 if pendingdata.type == aiohttp.WSMsgType.BINARY:
                     await self.datacallback(pendingdata.data)
                     continue
-                elif pendingdata.type ==  aiohttp.WSMsgType.CLOSE:
-                    await self.datacallback(conapi.ConsoleEvent.Disconnect)
-                    return
-                else:
-                    print("Unknown response in WSConsoleHandler")
+                elif pendingdata.type == aiohttp.WSMsgType.TEXT:
+                    await self.datacallback(pendingdata.data.encode())
+                    continue
+                # Every other message type means the socket is finished.  Once
+                # the peer is gone receive() answers CLOSED straight away and
+                # keeps doing so, so looping here would spin rather than wait.
+                if pendingdata.type != aiohttp.WSMsgType.CLOSE:
+                    _trace(
+                        'Console websocket for {0} ended with {1}{2}'.format(
+                            self.node, pendingdata.type.name,
+                            ': {0}'.format(pendingdata.data)
+                            if pendingdata.type == aiohttp.WSMsgType.ERROR
+                            else ''),
+                        event=log.Events.consoledisconnect)
+                self.connected = False
+                await self.datacallback(conapi.ConsoleEvent.Disconnect)
+                return
         except asyncio.CancelledError:
             pass
 
@@ -118,8 +151,12 @@ class OpenBmcConsole(conapi.Console):
         for ck in wc.cookies:
             if ck.key == 'XSRF-TOKEN':
                 protos = [ck.value]
-        self.ws = await self.clisess.ws_connect('wss://{0}/console0'.format(self.bmc), protocols=protos, ssl=self.ssl)
-    #self.ws.connect('wss://{0}/console0'.format(self.bmc), host=bmc, cookie='XSRF-TOKEN={0}; SESSION={1}'.format(wc.cookies['XSRF-TOKEN'], wc.cookies['SESSION']), subprotocols=[wc.cookies['XSRF-TOKEN']])
+        try:
+            self.ws = await self.clisess.ws_connect('wss://{0}/console0'.format(self.bmc), protocols=protos, ssl=self.ssl)
+        except Exception:
+            await self.clisess.close()
+            self.clisess = None
+            raise
         self.connected = True
         self.recvr = tasks.spawn_task(self.recvdata())
         return
@@ -127,8 +164,9 @@ class OpenBmcConsole(conapi.Console):
     async def write(self, data):
         try:
             await self.ws.send_str(data.decode())
-        except Exception as e:
-            print(repr(e))
+        except Exception:
+            _trace('Console websocket write for {0} failed:\n{1}'.format(
+                self.node, traceback.format_exc()))
             await self.datacallback(conapi.ConsoleEvent.Disconnect)
 
     async def close(self):
@@ -137,6 +175,10 @@ class OpenBmcConsole(conapi.Console):
             self.recvr = None
         if self.ws:
             await self.ws.close()
+            self.ws = None
+        if self.clisess:
+            await self.clisess.close()
+            self.clisess = None
         self.connected = False
         self.datacallback = None
 

--- a/confluent_server/confluent/plugins/console/tsmsol.py
+++ b/confluent_server/confluent/plugins/console/tsmsol.py
@@ -20,13 +20,33 @@
 # to use this.
 
 import asyncio
+import traceback
 import confluent.exceptions as cexc
 import confluent.interface.console as conapi
+import confluent.log as log
 import confluent.tasks as tasks
 import confluent.util as util
 import aiohmi.exceptions as pygexc
 import aiohmi.redfish.command as rcmd
 import aiohttp
+
+_tracelog = None
+
+
+def _trace(text, event=log.Events.stacktrace):
+    """Record a console problem where an operator can find it.
+
+    A daemon has nowhere useful to print to, and printing once per message
+    received is how a websocket that had already gone away managed to write
+    gigabytes of a single line.
+    """
+    global _tracelog
+    if _tracelog is None:
+        # Unbuffered: this records a console that has just gone away, and
+        # the daemon may not survive long enough to flush a buffered write.
+        _tracelog = log.Logger('trace', buffered=False)
+    _tracelog.log(text, ltype=log.DataTypes.event, event=event)
+
 
 class CustomVerifier(aiohttp.Fingerprint):
     def __init__(self, verifycallback):
@@ -96,11 +116,20 @@ class TsmConsole(conapi.Console):
                 elif pendingdata.type == aiohttp.WSMsgType.TEXT:
                     await self.datacallback(pendingdata.data.encode())
                     continue
-                elif pendingdata.type == aiohttp.WSMsgType.CLOSE:
-                    await self.datacallback(conapi.ConsoleEvent.Disconnect)
-                    return
-                else:
-                    print("Unknown response in WSConsoleHandler")
+                # Every other message type means the socket is finished.  Once
+                # the peer is gone receive() answers CLOSED straight away and
+                # keeps doing so, so looping here would spin rather than wait.
+                if pendingdata.type != aiohttp.WSMsgType.CLOSE:
+                    _trace(
+                        'Console websocket for {0} ended with {1}{2}'.format(
+                            self.node, pendingdata.type.name,
+                            ': {0}'.format(pendingdata.data)
+                            if pendingdata.type == aiohttp.WSMsgType.ERROR
+                            else ''),
+                        event=log.Events.consoledisconnect)
+                self.connected = False
+                await self.datacallback(conapi.ConsoleEvent.Disconnect)
+                return
         except asyncio.CancelledError:
             pass
 
@@ -133,8 +162,9 @@ class TsmConsole(conapi.Console):
     async def write(self, data):
         try:
             await self.ws.send_str(data.decode())
-        except Exception as e:
-            print(repr(e))
+        except Exception:
+            _trace('Console websocket write for {0} failed:\n{1}'.format(
+                self.node, traceback.format_exc()))
             await self.datacallback(conapi.ConsoleEvent.Disconnect)
 
     async def close(self):

--- a/confluent_server/confluent/plugins/hardwaremanagement/affluent.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/affluent.py
@@ -46,13 +46,15 @@ class WebClient(object):
                 'pubkeys.tls_hardwaremanager attribute'))
             return {}
         except (socket.gaierror, socket.herror, TimeoutError) as e:
-            results.put_nowait(msg.ConfluentTargetTimeout(self.node, str(e)))
+            results.put_nowait(
+                msg.ConfluentTargetTimeout(self.node, exc.exc_text(e)))
             return {}
         except OSError as e:
             if e.errno == 113:
                 results.put_nowait(msg.ConfluentTargetTimeout(self.node))
             else:
-                results.put_nowait(msg.ConfluentTargetTimeout(self.node), str(e))
+                results.put_nowait(
+                    msg.ConfluentTargetTimeout(self.node, exc.exc_text(e)))
             return {}
         except Exception as e:
             results.put_nowait(msg.ConfluentNodeError(self.node,

--- a/confluent_server/confluent/plugins/hardwaremanagement/enclosure.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/enclosure.py
@@ -29,11 +29,11 @@ async def reseat_bays(encmgr, bays, configmanager, rspq):
                         inputdata={'reseat': encbay}):
                     await rspq.put(rsp)
             except pygexc.UnsupportedFunctionality as uf:
-                await rspq.put(msg.ConfluentNodeError(node, str(uf)))
+                await rspq.put(msg.ConfluentNodeError(node, exc.exc_text(uf)))
             except exc.TargetEndpointUnreachable as uf:
-                await rspq.put(msg.ConfluentNodeError(node, str(uf)))
+                await rspq.put(msg.ConfluentNodeError(node, exc.exc_text(uf)))
             except Exception as e:
-                await rspq.put(msg.ConfluentNodeError(node, str(e)))
+                await rspq.put(msg.ConfluentNodeError(node, exc.exc_text(e)))
     finally:
         await rspq.put(None)
 

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -826,7 +826,9 @@ class IpmiHandler:
             # A list of users
             await self.output.put(msg.ChildCollection('all'))
             for user in await self.ipmicmd.get_users():
-                await self.output.put(msg.ChildCollection(user, candelete=True))
+                # The uids are numbers, and a link relation needs a string
+                await self.output.put(
+                    msg.ChildCollection(str(user), candelete=True))
             return
         # List all users
         elif len(self.element) == 4 and self.element[-1] == 'all':

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -808,7 +808,7 @@ class IpmiHandler:
                                     privilege_level=user['privilege_level'])
             # A list of users
             await self.output.put(msg.ChildCollection('all'))
-            async for user in self.ipmicmd.get_users():
+            for user in await self.ipmicmd.get_users():
                 await self.output.put(msg.ChildCollection(user, candelete=True))
             return
         # List all users

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -284,6 +284,18 @@ def _donothing(data):
     pass
 
 
+def exc_text(theexc):
+    """Render an exception for a user, even when it carries no message.
+
+    An error with no text at all tells the user nothing, so name the exception
+    when that is all we have.
+    """
+    text = str(theexc)
+    if not text or text == 'None':
+        return type(theexc).__name__
+    return text
+
+
 class IpmiConsole(conapi.Console):
     configattributes = frozenset(_configattributes)
     bmctonodemapping = {}
@@ -440,8 +452,12 @@ async def perform_request(operator, node, element,
             operator, node, element, configdata, inputdata, cfg, results,
             realop)
         return await ih.handle_request()
+    except pygexc.UnsupportedFunctionality as ue:
+        # Not an unexpected error, just something this target cannot do, so say
+        # so plainly and without a traceback in the log
+        await results.put(msg.ConfluentNodeError(node, exc_text(ue)))
     except pygexc.IpmiException as ipmiexc:
-        excmsg = str(ipmiexc)
+        excmsg = exc_text(ipmiexc)
         if excmsg in ('Session no longer connected', 'timeout'):
             await results.put(msg.ConfluentTargetTimeout(node))
         elif 'Unauthorized name' in excmsg or 'Incorrect password provided' in excmsg:
@@ -461,9 +477,10 @@ async def perform_request(operator, node, element,
             'Mismatch detected between target certificate fingerprint '
             'and pubkeys.tls_hardwaremanager attribute'))
     except pygexc.InvalidParameterValue as e:
-        await results.put(msg.ConfluentNodeError(node, str(e)))
+        await results.put(msg.ConfluentNodeError(node, exc_text(e)))
     except Exception as e:
-        await results.put(msg.ConfluentNodeError(node, 'Unexpected Error: {0}'.format(str(e))))
+        await results.put(msg.ConfluentNodeError(
+            node, 'Unexpected Error: {0}'.format(exc_text(e))))
         traceback.print_exc()
     finally:
         await results.put('Done')

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -604,6 +604,10 @@ class IpmiHandler:
             await self.handle_update()
         elif self.element[:3] == ['inventory', 'firmware', 'updatestatus']:
             await self.handle_update_status()
+        elif self.element[:3] == ['inventory', 'firmware', 'updatetypes']:
+            # Otherwise this falls through to the inventory handler and is read
+            # as the name of a firmware component
+            raise self._unsupported()
         elif self.element[0] == 'inventory':
             await self.handle_inventory()
         elif self.element == ['media', 'attach']:

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -838,7 +838,14 @@ class IpmiHandler:
             return
         # Update user
         elif len(self.element) == 4:
-            user = int(self.element[-1])
+            # ipmi users really are numbered slots, unlike redfish accounts, so
+            # say that rather than letting the conversion fail as a surprise
+            try:
+                user = int(self.element[-1])
+            except ValueError:
+                raise pygexc.InvalidParameterValue(
+                    'ipmi users are numbered, and "{0}" is not a user '
+                    'number'.format(self.element[-1]))
             if self.op == 'read':
                 data = await self.ipmicmd.get_user(uid=user)
                 await self.output.put(msg.User(

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -554,6 +554,17 @@ class IpmiHandler:
             self.ipmicmd = ipmicmd
             self.loggedin = True
 
+    def _unsupported(self):
+        """Say that the requested resource has no ipmi implementation.
+
+        Falling through to a bare exception would be reported as an unexpected
+        error and logged with a traceback, when all that happened is that this
+        transport does not offer the resource.
+        """
+        return pygexc.UnsupportedFunctionality(
+            '"{0}" is not implemented for ipmi'.format(
+                '/'.join([str(x) for x in self.element])))
+
     async def handle_request(self):
         if self.broken:
             if (self.error == 'timeout' or
@@ -622,7 +633,7 @@ class IpmiHandler:
         elif self.element == ['console', 'ikvm']:
             await self.handle_ikvm()
         else:
-            raise Exception('Not Implemented')
+            raise self._unsupported()
 
     async def handle_update(self):
         u = firmwaremanager.Updater(self.node, self.ipmicmd.update_firmware,
@@ -703,7 +714,7 @@ class IpmiHandler:
             return await self.handle_licenses()
         elif self.element[1:3] == ['management_controller', 'save_licenses']:
             return await self.save_licenses()
-        raise Exception('Not implemented')
+        raise self._unsupported()
 
     async def decode_alert(self):
         inputdata = self.inputdata.get_alert(self.node)
@@ -754,7 +765,7 @@ class IpmiHandler:
                 elif self.op == 'delete':
                     await self.ipmicmd.clear_alert_destination(alertidx)
                     return
-        raise Exception('Not implemented')
+        raise self._unsupported()
 
     async def handle_nets(self):
         if len(self.element) == 3:

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -1559,6 +1559,11 @@ class IpmiHandler:
         if self.element[3] == 'enabled':
             if 'read' == self.op:
                 enabled = await self.ipmicmd.get_ntp_enabled()
+                if enabled is None:
+                    # None is how the platform says it cannot tell us, and
+                    # reporting that as the text "None" tells the caller nothing
+                    raise pygexc.UnsupportedFunctionality(
+                        'NTP state is not reported by this platform')
                 await self.output.put(msg.NTPEnabled(self.node, enabled))
                 return
             elif 'update' == self.op:

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -455,7 +455,7 @@ async def perform_request(operator, node, element,
             await results.put(msg.ConfluentNodeError(node, excmsg))
             #raise
     except exc.TargetEndpointUnreachable as tu:
-        await results.put(msg.ConfluentTargetTimeout(node, str(tu)))
+        await results.put(msg.ConfluentTargetTimeout(node, exc_text(tu)))
     except ssl.SSLEOFError:
         await results.put(msg.ConfluentNodeError(
             node, 'Unable to communicate with the https server on '

--- a/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/ipmi.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import confluent.exceptions as exc
+from confluent.exceptions import exc_text
 import confluent.firmwaremanager as firmwaremanager
 import confluent.interface.console as conapi
 import confluent.messages as msg
@@ -282,18 +283,6 @@ def _donothing(data):
     # a dummy function to avoid some awkward exceptions from
     # zombie pyghmi console objects
     pass
-
-
-def exc_text(theexc):
-    """Render an exception for a user, even when it carries no message.
-
-    An error with no text at all tells the user nothing, so name the exception
-    when that is all we have.
-    """
-    text = str(theexc)
-    if not text or text == 'None':
-        return type(theexc).__name__
-    return text
 
 
 class IpmiConsole(conapi.Console):

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -334,10 +334,9 @@ async def perform_request(operator, node, element,
             realop)
         return await ih.handle_request()
     except socket.error as se:
-        if hasattr(se, 'strerror'):
-            await results.put(msg.ConfluentTargetTimeout(node, se.strerror))
-        else:
-            await results.put(msg.ConfluentTargetTimeout(node, str(se)))
+        # Every OSError has a strerror, but it is None on plenty of them, so
+        # ask for the text the same way as everywhere else rather than trust it
+        await results.put(msg.ConfluentTargetTimeout(node, exc_text(se)))
     except pygexc.IpmiException as ipmiexc:
         excmsg = exc_text(ipmiexc)
         if excmsg in ('Session no longer connected', 'timeout'):
@@ -346,7 +345,7 @@ async def perform_request(operator, node, element,
             await results.put(msg.ConfluentNodeError(node, excmsg))
             raise
     except exc.TargetEndpointUnreachable as tu:
-        await results.put(msg.ConfluentTargetTimeout(node, str(tu)))
+        await results.put(msg.ConfluentTargetTimeout(node, exc_text(tu)))
     except exc.TargetEndpointBadCredentials:
         await results.put(msg.ConfluentTargetInvalidCredentials(node))
     except ssl.SSLEOFError:

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -881,8 +881,10 @@ class IpmiHandler:
                     await self.output.put(msg.ConfluentTargetTimeout(self.node))
 
     async def list_inventory(self):
+        components = []
         try:
-            components = await self.ipmicmd.get_inventory_descriptions()
+            async for component in self.ipmicmd.get_inventory_descriptions():
+                components.append(component)
         except pygexc.IpmiException:
             await self.output.put(msg.ConfluentTargetTimeout(self.node))
             return

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -655,43 +655,13 @@ class IpmiHandler:
             await self.ipmicmd.install_bmc_certificate(cert)
 
     async def handle_alerts(self):
-        if self.element[3] == 'destinations':
-            if len(self.element) == 4:
-                # A list of destinations
-                maxdest = await self.ipmicmd.get_alert_destination_count()
-                for alertidx in range(0, maxdest + 1):
-                    await self.output.put(msg.ChildCollection(alertidx))
-                return
-            elif len(self.element) == 5:
-                alertidx = int(self.element[-1])
-                if self.op == 'read':
-                    destdata = await self.ipmicmd.get_alert_destination(alertidx)
-                    await self.output.put(msg.AlertDestination(
-                        ip=destdata['address'],
-                        acknowledge=destdata['acknowledge_required'],
-                        acknowledge_timeout=destdata.get('acknowledge_timeout', None),
-                        retries=destdata['retries'],
-                        name=self.node))
-                    return
-                elif self.op == 'update':
-                    alertparms = self.inputdata.alert_params_by_node(
-                        self.node)
-                    alertargs = {}
-                    if 'acknowledge' in alertparms:
-                        alertargs['acknowledge_required'] = alertparms['acknowledge']
-                    if 'acknowledge_timeout' in alertparms:
-                        alertargs['acknowledge_timeout'] = alertparms['acknowledge_timeout']
-                    if 'ip' in alertparms:
-                        alertargs['ip'] = alertparms['ip']
-                    if 'retries' in alertparms:
-                        alertargs['retries'] = alertparms['retries']
-                    await self.ipmicmd.set_alert_destination(destination=alertidx,
-                                                       **alertargs)
-                    return
-                elif self.op == 'delete':
-                    await self.ipmicmd.clear_alert_destination(alertidx)
-                    return
-        raise Exception('Not implemented')
+        # Redfish describes where to send events with the EventService
+        # subscription collection, which is a different model from the numbered
+        # ipmi PET destinations this resource was built around, so say so rather
+        # than calling methods the redfish client does not have
+        raise pygexc.UnsupportedFunctionality(
+            'Alert destinations are not implemented for redfish, use the '
+            'EventService subscriptions on the bmc directly')
 
     async def handle_nets(self):
         if len(self.element) == 3:
@@ -1437,9 +1407,23 @@ class IpmiHandler:
             await self.ipmicmd.set_domain_name(dn)
             return
 
+    _locationfields = ('room', 'location', 'building', 'rack', 'contactnames')
+
     async def handle_location_config(self):
         if 'read' == self.op:
-            lc = await self.ipmicmd.get_location_information()
+            await self.output.put(msg.KeyValueData(
+                await self.ipmicmd.get_location_information(), self.node))
+            return
+        elif 'update' == self.op:
+            attribs = self.inputdata.get_attributes(self.node)
+            locargs = {x: attribs[x] for x in self._locationfields
+                       if x in attribs}
+            if not locargs:
+                raise exc.InvalidArgumentException(
+                    'Location accepts only: {0}'.format(
+                        ', '.join(self._locationfields)))
+            await self.ipmicmd.set_location_information(**locargs)
+            return
 
     async def handle_bmcconfig(self, advanced=False, extended=False):
         if 'read' == self.op:

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -477,6 +477,8 @@ class IpmiHandler:
             await self.handle_update()
         elif self.element[:3] == ['inventory', 'firmware', 'updatestatus']:
             await self.handle_update_status()
+        elif self.element[:3] == ['inventory', 'firmware', 'updatetypes']:
+            await self.handle_update_types()
         elif self.element[0] == 'inventory':
             await self.handle_inventory()
         elif self.element == ['media', 'attach']:
@@ -922,6 +924,10 @@ class IpmiHandler:
         else:
             status = await self.ipmicmd.get_update_status()
             await self.output.put(msg.KeyValueData({'status': status}, self.node))
+
+    async def handle_update_types(self):
+        await self.output.put(msg.KeyValueData(
+            {'types': await self.ipmicmd.get_update_types()}, self.node))
 
     async def handle_inventory(self):
         if self.element[1] == 'firmware':

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -1438,6 +1438,13 @@ class IpmiHandler:
                 raise exc.InvalidArgumentException(
                     'Location accepts only: {0}'.format(
                         ', '.join(self._locationfields)))
+            contacts = locargs.get('contactnames', None)
+            if isinstance(contacts, str):
+                # A read answers with a list of names, but a caller setting one
+                # gives a string, and iterating that would make a contact of
+                # every letter
+                locargs['contactnames'] = [x.strip() for x in
+                                           contacts.split(',') if x.strip()]
             await self.ipmicmd.set_location_information(**locargs)
             return
 

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -272,6 +272,18 @@ def _donothing(data):
     pass
 
 
+def exc_text(theexc):
+    """Render an exception for a user, even when it carries no message.
+
+    An error with no text at all tells the user nothing, so name the exception
+    when that is all we have.
+    """
+    text = str(theexc)
+    if not text or text == 'None':
+        return type(theexc).__name__
+    return text
+
+
 async def perform_requests(operator, nodes, element, cfg, inputdata, realop):
     cryptit = cfg.decrypt
     cfg.decrypt = True
@@ -338,7 +350,7 @@ async def perform_request(operator, node, element,
         else:
             await results.put(msg.ConfluentTargetTimeout(node, str(se)))
     except pygexc.IpmiException as ipmiexc:
-        excmsg = str(ipmiexc)
+        excmsg = exc_text(ipmiexc)
         if excmsg in ('Session no longer connected', 'timeout'):
             await results.put(msg.ConfluentTargetTimeout(node))
         else:
@@ -357,10 +369,15 @@ async def perform_request(operator, node, element,
             node,
             'Mismatch detected between target certificate fingerprint '
             'and pubkeys.tls_hardwaremanager attribute'))
+    except pygexc.UnsupportedFunctionality as ue:
+        # Not an unexpected error, just something this target cannot do, so say
+        # so plainly and without a traceback in the log
+        await results.put(msg.ConfluentNodeError(node, exc_text(ue)))
     except (pygexc.InvalidParameterValue, pygexc.RedfishError) as e:
-        await results.put(msg.ConfluentNodeError(node, str(e)))
+        await results.put(msg.ConfluentNodeError(node, exc_text(e)))
     except Exception as e:
-        await results.put(msg.ConfluentNodeError(node, 'Unexpected Error: {0}'.format(str(e))))
+        await results.put(msg.ConfluentNodeError(
+            node, 'Unexpected Error: {0}'.format(exc_text(e))))
         traceback.print_exc()
     finally:
         await results.put('Done')

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -428,6 +428,17 @@ class IpmiHandler:
     }
 
 
+    def _unsupported(self):
+        """Say that the requested resource has no redfish implementation.
+
+        Falling through to a bare exception would be reported as an unexpected
+        error and logged with a traceback, when all that happened is that this
+        transport does not offer the resource.
+        """
+        return pygexc.UnsupportedFunctionality(
+            '"{0}" is not implemented for redfish'.format(
+                '/'.join([str(x) for x in self.element])))
+
     async def handle_request(self):
         if self.broken:
             if (self.error == 'timeout' or
@@ -494,7 +505,7 @@ class IpmiHandler:
         elif self.element == ['console', 'ikvm']:
             await self.handle_ikvm()
         else:
-            raise Exception('Not Implemented')
+            raise self._unsupported()
 
     async def update_firmware(self, filename, progress, data, bank):
         params=()
@@ -590,10 +601,11 @@ class IpmiHandler:
             return await self.handle_licenses()
         elif self.element[1:3] == ['management_controller', 'save_licenses']:
             return await self.save_licenses()
-        raise Exception('Not implemented')
+        raise self._unsupported()
 
     def decode_alert(self):
-        raise Exception("Decode Alert not implemented for redfish")
+        raise pygexc.UnsupportedFunctionality(
+            'Decoding an alert is not implemented for redfish')
 
     async def handle_cert_authorities(self):
         if len(self.element) == 3:

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -734,7 +734,10 @@ class IpmiHandler:
             return
         # Update user
         elif len(self.element) == 4:
-            user = int(self.element[-1])
+            # A redfish account is identified by a string, and an
+            # implementation is free to use the account name as one, so take it
+            # as given rather than assuming a number
+            user = self.element[-1]
             if self.op == 'read':
                 data = await self.ipmicmd.get_user(uid=user)
                 await self.output.put(msg.User(

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -513,7 +513,14 @@ class IpmiHandler:
         if self.inputdata.parameterdata:
             params = self.inputdata.parameterdata
         if params and isinstance(params, str):
-            params = json.loads(params)
+            try:
+                params = json.loads(params)
+            except ValueError as ve:
+                raise pygexc.InvalidParameterValue(
+                    'The parameter file is not valid json: {0}'.format(ve))
+        if params and not isinstance(params, dict):
+            raise pygexc.InvalidParameterValue(
+                'The parameter file must hold a json object, see nodefirmware(8)')
         return await self.ipmicmd.update_firmware(filename, progress=progress, data=data, bank=bank, otherfields=params)
 
     async def handle_update(self):

--- a/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
+++ b/confluent_server/confluent/plugins/hardwaremanagement/redfish.py
@@ -17,6 +17,7 @@ import json
 import asyncio
 import confluent.vinzmanager as vinzmanager
 import confluent.exceptions as exc
+from confluent.exceptions import exc_text
 import confluent.firmwaremanager as firmwaremanager
 import confluent.messages as msg
 import confluent.util as util
@@ -270,18 +271,6 @@ def _donothing(data):
     # a dummy function to avoid some awkward exceptions from
     # zombie pyghmi console objects
     pass
-
-
-def exc_text(theexc):
-    """Render an exception for a user, even when it carries no message.
-
-    An error with no text at all tells the user nothing, so name the exception
-    when that is all we have.
-    """
-    text = str(theexc)
-    if not text or text == 'None':
-        return type(theexc).__name__
-    return text
 
 
 async def perform_requests(operator, nodes, element, cfg, inputdata, realop):

--- a/confluent_server/setup.py.tmpl
+++ b/confluent_server/setup.py.tmpl
@@ -34,6 +34,7 @@ setup(
               'aiohmi/redfish/oem/lenovo',
               'aiohmi/redfish/oem/ami',
               'aiohmi/redfish/oem/megware',
+              'aiohmi/redfish/oem/openbmc',
               'aiohmi/util'],
     scripts=['bin/confluent', 'bin/confluent_selfcheck', 'bin/confluentdbutil', 'bin/collective', 'bin/osdeploy'],
     data_files=[('/etc/init.d', ['sysvinit/confluent']),


### PR DESCRIPTION
# Various fixes and features for AMI MegaRAC and OpenBMC BMCs

51 commits, 30 files, +1436/-289 against `master` at `8d519b57`. Nothing here is speculative: every
commit came out of running the real CLI tools against real hardware, and each failure was reproduced
at the `aiohmi` layer or with a raw request to the BMC before being attributed to a layer.

The recurring shapes are: a method the plugin calls that the Redfish client does not have, a write
sent without `If-Match` that the BMC silently drops, a read served from cache from before that write,
an `UnsupportedFunctionality()` carrying no message so the user sees `Unexpected Error` or nothing at
all, and an `async for` over something that is not an async iterator. Alongside those, three things
that were plainly broken rather than merely unhelpful: the device-SDR reader for BMCs with no SDR
repository, the 6-bit packed ASCII sensor-name decoder (an infinite loop), and a console websocket
that spun after its peer went away.

## Hardware tested

| BMC | transports | before | after |
|---|---|---|---|
| **AMI MegaRAC SPX 13** — MEGWARE EUREKA-LC-CN, Gigabyte MZ83-HD2, `ServiceRoot.v1_13_0` | redfish + ipmi | Where the work was developed. Identify unreadable, four Redfish resources raising `AttributeError`, firmware update aborting before the upload, hostname and NTP writes not sticking, `nodeconfig bmc` over IPMI killed by one missing DCMI command | 24 items fixed and re-verified on the BMC. `nodefirmware <n> update <file> -p <params.json>` now flashes BIOS and BMC images, with the kind of firmware named in the parameter file |
| **AMI MegaRAC SPX 12** — IBM ESS 3500, Viking VSSEP1EC | ipmi only | Re-test of those fixes on another vendor's MegaRAC, a firmware generation older. The Redfish half is untestable: the BMC answers `401 Security.1.0.AccessDenied` to everything below the service root, with basic auth, no auth, and its own web session cookie alike | The IPMI fixes hold unchanged. Turned up five more findings, four fixed; the 401 is a BMC-side problem, not confluent's |
| **OpenBMC `bmcweb` v3.11.1** — Celestica Artemis U.2 | redfish + ipmi | First non-AMI target, and the only machine where both transports ran in full. `nodehealth`, `nodesensors` and `nodeinventory` over IPMI all died with `Unexpected Error: NotImplementedError`; a console session that had gone away wrote 15 GB of log; a sensor-name decoder never terminated | 14 of 18 findings fixed, including both severe ones. IPMI sensors from nothing to 163, Redfish fans from 0 to 24, IPMI inventory from one FRU to nine, and values agree across the two transports |
| **Lenovo XCC2** — ThinkSystem SD665-N V3, XCC `15.30` | redfish + ipmi | Regression pass, not a survey: does any of the above break the platform confluent is built for? Run A/B against a pristine `master` worktree | **No regressions on either transport.** Ten defects that are live on `master` today work on the branch against this Lenovo, one of which leaves the daemon unkillable while an IPMI console is open |

OEM handler selection was checked on each: the Lenovo resolves to `aiohmi.redfish.oem.lenovo.xcc`,
the MegaRAC SPX 13 to the AMI handler via `Oem.Ami` on `Managers/Self`, and the OpenBMC correctly to
`generic`, since none of its `Oem` keys or model strings appears in `OEMMAP`, which makes that machine
a clean test of the plain generic Redfish path. The SPX 12 publishes `Vendor: "AMI"` at its service
root and so would resolve to the AMI handler too, but its Redfish half never got past the 401.

---

## Matrix 1: AMI MegaRAC SPX 13 (Gigabyte MZ83-HD2)

**This table is the state as found on `master`**, which is what the pass was measuring. It is
deliberately not updated as things were repaired; the fix table below it says what changed.

Legend: **ok** works correctly; **partial** works with a caveat; **broken** confluent defect;
**bmc** the BMC does not offer it and confluent says so correctly; **n/t** not tested.

| Tool / resource | redfish | ipmi | note |
|---|---|---|---|
| `nodepower` (query, `status`/`stat`/`state`) | ok | ok | |
| `nodepower -p` | ok | ok | prints `on->on` on a pure query |
| `nodepower on` (already on) | ok | ok | correct no-op, no power event |
| `nodepower pdu_status` | ok | ok | correctly 404s, no `power.*` attributes on these nodes |
| `nodepower off`/`shutdown`/`boot`/`reset` | n/t | n/t | previously verified; not re-run (no reboot/power-off) |
| `nodehealth` | ok | ok | first IPMI call takes ~40 s (SDR load) |
| `nodesensors` (all/temp/power) | ok | ok | 62 sensors via redfish, 46 via IPMI; 19 report `State: Absent` |
| `nodesensors fans`/`energy` | bmc | bmc | empty, exit 0 (fans belong to the enclosure) |
| `nodesensors <name>`, `-c` | ok | ok | |
| `sensors/hardware/leds` | **broken** | ok | R2 `get_leds` missing |
| `nodeinventory` | ok | ok | redfish: DIMMs/adapters/NVMe; IPMI: FRU/board |
| `nodeinventory mac` | ok | partial | IPMI prints nothing, exit 0 (C7) |
| `nodefirmware` (list) | ok | partial | redfish: 5 components incl. dual BMC image; IPMI: only `BMC Version` |
| `nodefirmware <category>` | **broken** | n/a | R13 category ignored, all four identical |
| `nodefirmware updatestatus` | ok | bmc | IPMI unsupported, but printed as a raw dict (C1) |
| `nodefirmware update` (BIOS) | **broken** | bmc | R9 + R10 |
| `nodefirmware update` (BMC) | **broken** | bmc | R9 + R10 + R18: flash succeeds but is reported as an error |
| `nodeeventlog` (read, `-l`, `-t`) | ok | ok | redfish merges SEL + EventLog + AuditLog |
| `nodeeventlog clear` | partial | ok | R17 redfish clears AuditLog too |
| `events/hardware/decode` | **broken** | ok | not implemented for redfish |
| `nodesetboot` (set) | ok | ok | network/hd/cd/setup/usb/floppy/default, `-b`/`-u`/`-p` |
| `nodesetboot` (read) | partial | ok | R7 stale for up to 30 s after a write |
| `nodeboot` | ok | ok | verified end to end with a real reboot |
| `nodeidentify` (set) | ok | partial | IPMI `blink` → clean "not supported with generic IPMI" |
| `nodeidentify` (read) | **broken** | bmc | R1; IPMI read is intentionally empty |
| `nodeconfig` read, BMC net/hostname/NTP | ok | ok | |
| `nodeconfig` read, system/UEFI | ok | bmc | 1002 BIOS attributes with help + defaults + allowables |
| `nodeconfig` write, system/UEFI | bmc | bmc | R12 read-only on this BMC (PATCH → 405) |
| `nodeconfig bmc.hostname=` | **broken** | partial | R6 missing If-Match; IPMI is silent and deferred |
| `nodeconfig` NTP write | **broken** | bmc | R6 missing If-Match |
| `nodeconfig bmc.ipv4_*` write | **broken** | bmc | R6, inferred (not exercised: would risk losing access) |
| `extended/all` | bmc | bmc | `{}` (generic returns nothing) |
| `extended/extra` | **broken** | **broken** | R4 empty error message; I2 `hideadvanced` TypeError |
| `management_controller/identifier` | **broken** | ok | R2 `get_mci` missing |
| `management_controller/domain_name` | **broken** | ok | R2 `get_domain_name` missing |
| `management_controller/location` | **broken** | bmc | R5 result fetched and discarded |
| `alerts/destinations` | **broken** | ok | R2 four missing methods |
| `management_controller/users` (list) | ok | **broken** | I1 `async for` on a coroutine |
| user create | ok | partial | IPMI creates then crashes formatting the reply (I1) |
| user delete | **broken** | n/t | R11 |
| `nodebmcpassword` | ok | ok | verified by re-authenticating as the changed user |
| `nodebmcreset` | ok | ok | ~3.5 min to come back; IPMI error text is `None` when unreachable (I3) |
| `console/license` | **broken** | ok | R2 `get_remote_kvm_available` missing |
| `description` | **broken** | partial | R3 signature mismatch; IPMI returns `{}` |
| `nodemedia list` | partial | **broken** | empty on redfish; IPMI raises with an empty message (I3) |
| `nodemedia attach` | **broken** | bmc | R8 silent no-op; BMC's own `InsertMedia` target 404s |
| `nodestorage show` | bmc | bmc | clean "not supported"; one NVMe namespace, no RAID |
| `nodelicense list` | **broken** | **broken** | I3 no output at all, exit 0 |
| `nodesupport servicedata` | bmc | bmc | not implemented for either; C3 masks the real error |
| `nodereseat` | **broken** | bmc | R14 hardcoded Nvidia/`Chassis_0` path |
| `nodeconsole` (SOL) | n/a | partial | I7 racy connect, `IpmiException: None`; does capture real output |
| `nodeconsole -s` / iKVM | **broken** | **broken** | R15 no iKVM support; C4 client-side crash |

### What changed on that BMC

| finding | state | how it was verified |
|---|---|---|
| R1 `get_identify` | fixed | `nodeidentify rf` returns the state; prefers a single-system chassis, the copy this firmware keeps current |
| R3 `get_description` | fixed | returns `{}` (no `HeightMm` here) instead of a TypeError |
| R6 PATCH without If-Match | fixed | `set_hostname` applied a new hostname and it stuck; NTP now reaches the BMC |
| I1 `async for` on `get_users` | fixed | users collection lists uid 2 again. A slot the bmc refuses to describe is skipped, while a timeout or a lost session mid-enumeration is reported rather than passing as a user list that ended early |
| I2 `hideadvanced` | fixed | `extended/extra` and `extended/extra_advanced` return `{}` |
| R9 AMI `PreserveConfiguration` | fixed | intersects with what the BMC advertises |
| R10 multipart `UpdateParameters` | fixed | **`nodefirmware rf update <file> -p <params.json>` flashes**, BIOS and BMC images both, with `{"OemParameters": {"ImageType": "BIOS"}}` in the parameter file |
| `nodefirmware <n> updatetypes` | new | names the kinds of firmware image a platform has to be told about, without attempting an update. Confirmed live on a second AMI MegaRAC returning nine values, and refusing honestly on the Lenovo and the OpenBMC, which read the kind from the image |
| R18 BMC restart during apply | fixed | the race did not recur; the tolerance is a guard |
| I3/R4 empty error text | fixed | every `UnsupportedFunctionality()` carries a message; unsupported no longer prints as "Unexpected Error" |
| R7 stale reads | fixed | set-then-read of identify and boot device agrees with the BMC every time |
| R2 missing Redfish methods | fixed | leds, identifier, domain_name, console/license answer; alerts says plainly it is not implemented for redfish |
| R5 location | fixed | emits the location (`{}` here) instead of nothing |
| R11 user delete | fixed | five cases unit-tested including the MegaRAC timeout-then-retry path |
| R8 virtual media | fixed | no longer a silent success: reports the BMC's real refusal ("Image is a read only property") |
| R13 firmware category | fixed | `core` lists everything, `adapters`/`disks`/`misc` correctly report nothing |
| R14 reseat | fixed | "Reseat is not supported on this platform", matching the IPMI wording |
| I7 SOL error text | fixed | `IpmiException: timeout` instead of `IpmiException: None` |
| C1-C7 client | fixed | raw dict, tuple errors, both `nodeconsole` crashes, `nodedefine` usage, exit codes for `nodestorage`/`nodelicense`/`nodesupport` |
| OEM lookup short-circuit | fixed | the early lookup reads the manager document, so one handler serves the whole connection |
| I4 discrete sensor rendering | fixed | `Watchdog:%` and `SEL:` no longer print a unit with no reading |
| I5 IPMI NTP misreport | fixed | `ntp/enabled` reported the string `"None"` and now says it is not reported |
| I6 `nodeinventory <n> mac` silent | fixed | says `No mac reported for "ipmi"` instead of printing nothing |
| V2 empty `nodereseat` error | fixed | one shared `exc_text()` with an `apierrorstr` fallback |
| V3 IPMI `location` bare `Exception` | fixed | the not-implemented fall-throughs name the resource |

---

## Matrix 2: OpenBMC `bmcweb` v3.11.1 (Celestica Artemis U.2)

Both transports in full, before and after in each cell.

| tool / path | redfish | ipmi | note |
|---|---|---|---|
| `nodepower` (query) | ok | ok | |
| `nodehealth` | ok | **broken**, now fixed | **O1**, was `Unexpected Error: NotImplementedError`, now `ok` |
| `nodesensors all` / `temperature` / `power` | ok | **broken**, now fixed | 126 over Redfish, 163 over IPMI after **O1**; values agree |
| `nodesensors fans` / `energy` | **broken**, now fixed | ok after **O1** | **O5**: Redfish went 0 to 24 tachs, IPMI reads all 36 |
| `nodesensors <name>` | ok | - | |
| `nodeinventory` | ok | partial, now fixed | 134 lines over Redfish; IPMI went from one FRU to nine after **O1** |
| `nodeinventory` CPU | partial, now fixed | - | **O14**, was one field and empty here; now model, maker, socket, cores, threads, speed |
| `nodefirmware` list / categories | partial, labels now fixed | ok | **O15** labels, now `Host image`/`CPLD image`/`BMC image` |
| `nodefirmware` (during BMC init) | - | **broken**, now fixed | **O9**, reported `131.11` instead of `3.11` |
| `nodeeventlog` read | **wrong log**, now fixed | ok | **O4**, was a page of BMC journal, now the 292-entry event log |
| `nodeeventlog clear` | **no-op**, now fixed | ok | **O4**, cleared Dump and FaultLog and not the event log; now the event log only |
| `nodesetboot` all targets, `-b`/`-u`/`-p` | ok | ok | verified against the BMC after every write |
| `nodeidentify` read | unsupported, clean | empty, exit 0 | **V6** again over IPMI |
| `nodeidentify` write | **broken**, now fixed | unsupported | **O7** over Redfish, now a clean unsupported |
| `nodeconfig` bmc read | ok | **broken**, now fixed | **O2** over IPMI; after the fix it matches Redfish field for field |
| `nodeconfig` system read | **broken**, now fixed | empty | **O8**, phantom `Bios` link no longer aborts the read |
| `nodeconfig bmc.hostname` write | works, then locks you out | ok | **O13**, still open |
| `configuration/.../users` list | ok | ok | |
| `configuration/.../users/<id>` | **broken**, now fixed | ok | **O6**, `int('root')`; `nodebmcpassword` depends on it |
| `configuration/.../alerts/destinations` | unsupported, clean | **broken**, now fixed | **O3**, was a raw completion code, now says the platform has none |
| `nodemedia`, `nodestorage`, `nodelicense`, `nodereseat`, `nodesupport` | unsupported, clean | unsupported, clean | the platform has none of these |
| `nodeconsole` (SOL / openbmc) | connects | connects | no output, host side; **O10** on disconnect, now fixed |
| `nodeconsole -s` | **broken** | **broken** | **O12**, still open |
| `nodebmcreset` | ok | ok | back in ~80 s and ~75 s, host stayed powered |

---

## Matrix 3: Lenovo XCC2 (ThinkSystem SD665-N V3)

149 commands per tree, run against the branch and against a pristine `master` worktree: 90 read-only
(power, health, inventory, sensors, firmware, event log, boot, identify, config, media, storage,
licenses, plus 32 `confetty` resource reads), 31 reversible writes, 28 collection and output-mode
variants. **There is no case where `master` produced a correct answer and the branch did not.**

Checked for equality rather than merely for absence of errors:

| checked | master | branch |
|---|---|---|
| IPMI sensor names and count (`tlv_decode` was rewritten) | 309 sensors | 309, byte-identical names |
| Redfish sensor names and count | 34 sensors | 34, identical |
| Full event log, all sources (`get_event_log` was restructured) | 2224 events, `MaintenanceLog` + `SaLog` + `AuditLog` | 2224 events, same sources, identical set |
| Firmware inventory, both transports | identical | identical, except the F9 fix below |
| `nodeconfig <n> bmc`, both transports | identical key set | identical key set |
| Inventory key set, both transports | identical | identical |
| SOL console attach on `lipmi` | connects, replays buffer | connects, replays buffer |
| `nodesetboot` write, five targets over Redfish, three over IPMI | write accepted | write accepted |

Ten behaviours that are broken on `master` against this XCC and work on the branch. None was found
*on* a Lenovo; they turned up on the AMI and OpenBMC targets and happen to be broken here too:

| id | command | master | branch |
|---|---|---|---|
| F1 | `nodeidentify lrf` | `Unexpected Error: <bound method Command.sysinfo of ...>` | the identify state |
| F2 | `nodesetboot lrf <dev>` then read back | the old value for up to 30 s | the value just written |
| F3 | `configuration/management_controller/identifier` (and `domain_name`, `location`, `net_interfaces/management`) | `'IpmiCommandWrapper' object has no attribute 'get_mci'` | `identifier="h13-15"` |
| F4 | `confetty show /nodes/lrf/inventory/hardware/all` | `'async_generator' object can't be awaited` | 42 lines: dimm_1..24, disk_1, processor_1..2, the HGX H100s |
| F5 | `confetty show /nodes/lipmi/configuration/management_controller/users` | `'async for' requires an object with __aiter__ method, got coroutine` | `all, 1` |
| F6 | `nodeconfig lipmi -a bmc` | `'NoneType' object has no attribute 'grab_json_response'` | 21 settings incl. `bmc.smm`, `bmc.smm_ip`, the password policy set |
| F7 | `nodesupport <n> servicedata /tmp/file` | no output at all, exit 0 | the bundle, or a reason it could not be written |
| F8 | `nodeinventory lipmi` / `nodeeventlog lipmi -l 5` | `timeout` (exit 248) | 382 lines of inventory / 5 events |
| F9 | `nodefirmware lipmi adapters` | 10 adapters plus `BMC Version: 15.30` | 10 adapters |
| F10 | `SIGTERM` with a live IPMI console session | daemon does not stop | gone in 0.25 s, pid file removed |

Still broken on both trees, recorded as pre-existing rather than fixed here:

| id | command | both trees |
|---|---|---|
| P1 | `confetty show /nodes/lipmi/console/graphical` | `'WebConnection' object has no attribute 'connect'`, in Lenovo-only code |
| P2 | `nodesensors lrf power` / `energy` / `fans` | empty, exit 0, while IPMI reads `Sys Power: 660.0 W`, `DC Energy: 262.9 kWh` |
| P3 | `nodesensors <n> leds` | `Error: Sensor not found` — `leds` is a category, nothing filters on it |
| P4 | — | `vtbufferd` respawned with no backoff; an orphan holding the socket burns a full core |
| P5 | `nodemedia <n> list` | empty, exit 0, with 10 empty `VirtualMedia` slots published |

---

## Matrix 4: AMI MegaRAC SPX 12 (IBM ESS 3500, Viking board)

IPMI only. `nodepower` (query), `nodehealth`, `nodesensors` (all, by category, by name, `-c` CSV),
`nodeinventory` (bare, `-j`, `serial`/`uuid`/`mac`/`all`), `nodefirmware`, `nodeeventlog` (bare,
`-l`, `-t 24h`), `nodesetboot` across `network`/`hd`/`setup`/`cd` in `-b`/`-u`/`-p` and back to
`default`, `nodeidentify on`/`off`, and an SOL session through `nodeconsole` all behave correctly.
The boot override and the identify LED were restored afterwards. What the earlier fixes did here:

| fix | result |
|---|---|
| **I1** `get_users` per-slot tolerance | `users/all` lists uid 2 out of 10 slots with no error |
| **I2** `hideadvanced` on the IPMI path | `extended/all` and `extended/extra` return empty rather than raising |
| **I3/R4** a message on every unsupported operation | the most visible improvement here: `nodemedia list`, `nodestorage show`, `nodelicense list`, `nodefirmware updatestatus`, `nodereseat`, `nodeidentify blink` each name the reason, exit 244 |
| **I5** honest NTP state | `ntp/enabled` says it is not reported instead of the string `"None"` |
| **I6** silent inventory filter | `nodeinventory ipmi mac` prints `No mac reported for "ipmi"` |
| **I4** client half of discrete sensors | no unit printed without a reading across 80 sensors |
| **C2** `nodeconsole -s` needs a terminal | says so instead of tracebacking |
| **C5** non-tty log replay | `nodeconsole ipmi -l` and `-l -T` dump the log instead of failing |
| **C6** `nodedefine` usage error | `nodedefine rf ipmi` says `Attributes must be given as attribute=value, got "ipmi"` |
| **C3/C4/C7** report failures, exit non-zero | `nodesupport servicedata` prints the reason and exits 1 |
| **S1** clean shutdown | SIGTERM with a live IPMI session: process gone in **0.25 s**, pid file removed |
| **AMI CSRF header** (`X-CSRFTOKEN`) | `megarac.get_wc()` authenticates; `/api/chassis-status` and `/api/settings/services` answer 200 on a fresh and a reused session |
| everything Redfish | untestable: the BMC 401s these credentials, reproducible with plain `curl` and no confluent involved |

Confluent handles that refusal correctly: all 20 CLI invocations and 21 raw resource paths reported
`bad credentials` (`502` over the API) and none wrote a traceback.

---

## Automated tests

Automated test against BMCs can be run using these scripts: [confluent-bmc-tests.zip](https://github.com/user-attachments/files/31100768/confluent-bmc-tests.zip)



