### PR TITLE
Say why a session broke

### DIFF
--- a/confluent_server/aiohmi/ipmi/private/session.py
+++ b/confluent_server/aiohmi/ipmi/private/session.py
@@ -575,7 +575,9 @@ class Session(object):
             pass
         await self.logout(False)
         # self.logging = False
-        self.errormsg = error
+        # This is what a broken session raises with, so it has to say something
+        # even when the caller did not, and the first reason is the useful one
+        self.errormsg = error or getattr(self, 'errormsg', None) or 'Session failed'
         if not self.broken:
             self.broken = True
             if self.socket:
@@ -781,7 +783,7 @@ class Session(object):
                     waiter({'success': True})
                 await self.process_pktqueue()
                 if _monotonic_time() > alltimeout:
-                    await self._mark_broken()
+                    await self._mark_broken('Session no longer connected')
                     raise exc.IpmiException('Session no longer connected')
                 await WAITING_SESSIONS.acquire()
                 try:
@@ -815,7 +817,7 @@ class Session(object):
         if not self.logged:
             if (self.logoutexpiry is not None
                     and _monotonic_time() > self.logoutexpiry):
-                await self._mark_broken()
+                await self._mark_broken('Session no longer connected')
             raise exc.IpmiException('Session no longer connected')
         await self.atomicop.acquire()
         try:
@@ -1371,8 +1373,8 @@ class Session(object):
                                            callback=self._keepalive_wrapper(None))
                 else:
                     await self.logout()
-        except exc.IpmiException:
-            await self._mark_broken()
+        except exc.IpmiException as ie:
+            await self._mark_broken(str(ie) or 'Session keepalive failed')
 
     async def process_pktqueue(self):
         while self.pktqueue:
@@ -1810,7 +1812,7 @@ class Session(object):
                 if self.ipmicallback:
                     await self.ipmicallback(response)
                 self.nowait = False
-                await self._mark_broken()
+                await self._mark_broken('timeout')
                 return
             else:
                 self.maxtimeout = 2
@@ -1847,7 +1849,7 @@ class Session(object):
                 if self.ipmicallback:
                     await self.ipmicallback(response)
                 self.nowait = False
-                await self._mark_broken()
+                await self._mark_broken('timeout')
                 return
         else:  # in IPMI case, the only recourse is to act as if the packet is
             # idempotent.  SOL has more sophisticated retry handling


### PR DESCRIPTION
Five of the seven _mark_broken calls named no reason, so errormsg stayed None and a broken session raised IpmiException whose text was the string "None", which is what a console attach against an unreachable bmc reported.

The reasons given are the two the ipmi plugin already classifies by name, so a session that timed out or went away now reaches the user as a timeout rather than an unexpected error.  A caller that still says nothing leaves a generic message behind rather than None, and an earlier reason is not overwritten.