### PR TITLE
Fix advanced XCC BMC settings

### DIFF
--- a/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
+++ b/confluent_server/aiohmi/ipmi/oem/lenovo/imm.py
@@ -1028,7 +1028,7 @@ class XCCClient(IMMClient):
         return {'height': int(dsc['u-height']), 'slot': int(dsc['slot'])}
 
     async def get_extended_bmc_configuration(self, hideadvanced=True):
-        immsettings = await self.get_system_configuration(fetchimm=True)
+        immsettings = await self.get_system_configuration(hideadvanced=hideadvanced, fetchimm=True)
         for setting in list(immsettings):
             if not setting.startswith('IMM.'):
                 del immsettings[setting]


### PR DESCRIPTION
Disabled this by accident when doing the async fixes. Upstream pyghmi passess this as well.